### PR TITLE
fix(ci): drop uv cache from Deploy Docs workflow

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -16,8 +16,6 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@v3
-        with:
-          enable-cache: true
 
       - name: Set up Python
         run: uv python install 3.12


### PR DESCRIPTION
## Summary

The "Deploy Docs" workflow (added in PR #32) failed on its first run on `main` ([run 26510448066](https://github.com/jejjohnson/vardax/actions/runs/26510448066)) with:

```
Error: No file in /home/runner/work/vardax/vardax matched to [**/uv.lock],
make sure you have checked out the target repository
```

`astral-sh/setup-uv@v3` with `enable-cache: true` requires a `uv.lock` file to key the cache on. vardax's `.gitignore` excludes `uv.lock` (no committed lockfile), so the cache action couldn't resolve and the job failed before even reaching `mkdocs gh-deploy`.

The `enable-cache: true` was a copy-paste from pipekit's workflow — pipekit commits its `uv.lock`, vardax doesn't.

## Fix

Drop the `enable-cache: true` option. The other vardax workflows (`ci.yml`, `format.yml`, `lint.yml`, `typecheck.yml`) all use `astral-sh/setup-uv@v3` without `enable-cache` and work fine. Resolution time without the cache is ~30s — not worth introducing a committed lockfile to recover.

## Test plan

- [ ] Merge → next push to `main` runs Deploy Docs → expect success → docs visible at https://jejjohnson.github.io/vardax/

---
_Generated by [Claude Code](https://claude.ai/code/session_013jMD55Uea3GA332USkaR7w)_