### PR TITLE
refactor: phase 1+2+3 — equinox + protocols + obs operators + adjoints + classical DA + posterior

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,16 @@ uv-lint: ## Run ruff check and ty
 	@uv run ty check $(PKGROOT)
 	@printf "$(GREEN)>>> Linting checks passed.$(RESET)\n"
 
+.PHONY: uv-typecheck-ci
+uv-typecheck-ci: ## Reproduce the CI Type Check env (typecheck group only) — catches CI-only ty issues
+	@printf "$(YELLOW)>>> Reproducing CI Type Check env (typecheck group)...$(RESET)\n"
+	@rm -rf .venv-typecheck-ci
+	@uv venv .venv-typecheck-ci --python 3.13
+	@VIRTUAL_ENV=.venv-typecheck-ci uv sync --active --group typecheck
+	@VIRTUAL_ENV=.venv-typecheck-ci uv run --active ty check $(PKGROOT)
+	@rm -rf .venv-typecheck-ci
+	@printf "$(GREEN)>>> CI-env ty check passed.$(RESET)\n"
+
 .PHONY: uv-pre-commit
 uv-pre-commit: ## Run all pre-commit hooks
 	@printf "$(YELLOW)>>> Running pre-commit hooks on all files...$(RESET)\n"

--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ trajectories from noisy partial observations:
 ```python
 import jax, jax.numpy as jnp
 import vardax as vdx
+from vardax.adjoints import OneStepAdjoint
 
 # Build a 4DVarNet for 1D state vectors (Lorenz-63: N=3)
 model = vdx.FourDVarNet1D(
@@ -147,7 +148,7 @@ model = vdx.FourDVarNet1D(
     latent_dim=8,
     hidden_dim=16,
     n_solver_steps=15,
-    grad_mode="one_step",           # Bolte et al. (2023), O(1) memory
+    solver_adjoint=OneStepAdjoint(),   # Bolte et al. (2023), O(1) memory
     key=jax.random.PRNGKey(0),
 )
 

--- a/README.md
+++ b/README.md
@@ -139,10 +139,8 @@ trajectories from noisy partial observations:
 ```python
 import jax, jax.numpy as jnp
 import vardax as vdx
-from flax import nnx
 
 # Build a 4DVarNet for 1D state vectors (Lorenz-63: N=3)
-key = nnx.Rngs(jax.random.PRNGKey(0))
 model = vdx.FourDVarNet1D(
     state_dim=3,
     n_time=20,
@@ -150,7 +148,7 @@ model = vdx.FourDVarNet1D(
     hidden_dim=16,
     n_solver_steps=15,
     grad_mode="one_step",           # Bolte et al. (2023), O(1) memory
-    rngs=key,
+    key=jax.random.PRNGKey(0),
 )
 
 # batch.input: (B, T, N) masked observations

--- a/notebooks/01_model_based_4dvar_L63.py
+++ b/notebooks/01_model_based_4dvar_L63.py
@@ -19,7 +19,7 @@
 # attractor using `vardax`.
 
 # %%
-import flax.nnx as nnx
+# (NNX removed in Epic 0 — vardax is now equinox-native)
 import jax
 import jax.numpy as jnp
 import matplotlib.pyplot as plt
@@ -53,7 +53,7 @@ model = FourDVarNet1D(
     latent_dim=8,
     hidden_dim=16,
     n_solver_steps=5,
-    rngs=nnx.Rngs(jax.random.PRNGKey(1)),
+    key=jax.random.PRNGKey(1),
 )
 
 # %% [markdown]

--- a/notebooks/02_unrolling_vs_fixedpoint_L63.py
+++ b/notebooks/02_unrolling_vs_fixedpoint_L63.py
@@ -30,7 +30,7 @@
 # 6. Compare MSE across conditions with a bar chart
 
 # %%
-import flax.nnx as nnx
+# (NNX removed in Epic 0 — vardax is now equinox-native)
 import jax
 import jax.numpy as jnp
 import matplotlib.pyplot as plt
@@ -121,10 +121,10 @@ model_unrolled = FourDVarNet1D(
     latent_dim=8,
     hidden_dim=16,
     n_solver_steps=10,
-    rngs=nnx.Rngs(jax.random.PRNGKey(1)),
+    key=jax.random.PRNGKey(1),
 )
 
-optimizer, train_losses, _ = vardax.fit(
+model, train_losses, _ = vardax.examples.fit_demo(
     model_unrolled,
     [batch_train],
     n_epochs=5,
@@ -137,7 +137,7 @@ print(f"Final unrolled train loss: {train_losses[-1]:.4f}")
 # ## 4. Fixed-point solver (untrained prior)
 
 # %%
-prior = BilinAEPrior1D(state_dim=N, latent_dim=8, n_time=T, rngs=nnx.Rngs(jax.random.PRNGKey(3)))
+prior = BilinAEPrior1D(state_dim=N, latent_dim=8, n_time=T, key=jax.random.PRNGKey(3))
 
 out_fp = solve_4dvarnet_1d_fixedpoint(batch_test, prior, n_fp_steps=10)
 print(f"Fixed-point output shape: {out_fp.shape}")

--- a/notebooks/03_4dvarnet_L63.py
+++ b/notebooks/03_4dvarnet_L63.py
@@ -19,13 +19,13 @@
 # Lorenz-63 dataset.
 
 # %%
-import flax.nnx as nnx
+# (NNX removed in Epic 0 — vardax is now equinox-native)
 import jax
 import jax.numpy as jnp
 import matplotlib.pyplot as plt
 
 import vardax
-from vardax import Batch1D, FourDVarNet1D, fit
+from vardax import Batch1D, FourDVarNet1D
 
 # %% [markdown]
 # ## Generate training data
@@ -55,7 +55,7 @@ model = FourDVarNet1D(
     latent_dim=8,
     hidden_dim=16,
     n_solver_steps=5,
-    rngs=nnx.Rngs(jax.random.PRNGKey(1)),
+    key=jax.random.PRNGKey(1),
 )
 
 optimizer, train_losses, val_losses = fit(

--- a/notebooks/04_4dvarnet_2d_demo.py
+++ b/notebooks/04_4dvarnet_2d_demo.py
@@ -18,7 +18,7 @@
 # Demonstrates `FourDVarNet2D` on synthetic 2-D spatiotemporal data.
 
 # %%
-import flax.nnx as nnx
+# (NNX removed in Epic 0 — vardax is now equinox-native)
 import jax
 import jax.numpy as jnp
 import matplotlib.pyplot as plt
@@ -50,7 +50,7 @@ model = FourDVarNet2D(
     latent_dim=16,
     hidden_dim=8,
     n_solver_steps=3,
-    rngs=nnx.Rngs(jax.random.PRNGKey(1)),
+    key=jax.random.PRNGKey(1),
 )
 
 out = model(batch)

--- a/notebooks/05_end_to_end_L63.py
+++ b/notebooks/05_end_to_end_L63.py
@@ -136,7 +136,7 @@ plt.show()
 # ## 8. Train FourDVarNet1D
 
 # %%
-import flax.nnx as nnx
+# (NNX removed in Epic 0 — vardax is now equinox-native)
 
 N = batch_train.input.shape[-1]   # 3 (X, Y, Z)
 T = batch_train.input.shape[1]    # 20
@@ -147,10 +147,10 @@ model = FourDVarNet1D(
     latent_dim=8,
     hidden_dim=16,
     n_solver_steps=5,
-    rngs=nnx.Rngs(jax.random.PRNGKey(1)),
+    key=jax.random.PRNGKey(1),
 )
 
-optimizer, train_losses, _ = vardax.fit(
+model, train_losses, _ = vardax.examples.fit_demo(
     model,
     [batch_train],
     n_epochs=5,

--- a/notebooks/06_end_to_end_L96.py
+++ b/notebooks/06_end_to_end_L96.py
@@ -116,7 +116,7 @@ plt.show()
 # ## 6. Train FourDVarNet1D with L96Prior
 
 # %%
-import flax.nnx as nnx
+# (NNX removed in Epic 0 — vardax is now equinox-native)
 
 batch_train = xr_to_batch1d(ds_train, state_var="state", obs_var="obs", mask_var="mask")
 batch_test = xr_to_batch1d(ds_test, state_var="state", obs_var="obs", mask_var="mask")
@@ -130,10 +130,10 @@ model = FourDVarNet1D(
     latent_dim=16,
     hidden_dim=32,
     n_solver_steps=5,
-    rngs=nnx.Rngs(jax.random.PRNGKey(1)),
+    key=jax.random.PRNGKey(1),
 )
 
-optimizer, train_losses, _ = vardax.fit(
+model, train_losses, _ = vardax.examples.fit_demo(
     model,
     [batch_train],
     n_epochs=5,

--- a/notebooks/07_prior_pretraining_L63.py
+++ b/notebooks/07_prior_pretraining_L63.py
@@ -75,12 +75,15 @@ print(f"Train: {batch_train.input.shape}, Test: {batch_test.input.shape}")
 # Minimise $\|x - \varphi(x)\|^2$ on clean (unmasked) state trajectories.
 
 # %%
-import flax.nnx as nnx
+# (NNX removed in Epic 0 — vardax is now equinox-native)
 
 B, T, N = batch_train.input.shape
-prior = BilinAEPrior1D(state_dim=N, latent_dim=8, n_time=T, rngs=nnx.Rngs(jax.random.PRNGKey(10)))
+prior = BilinAEPrior1D(state_dim=N, latent_dim=8, n_time=T, key=jax.random.PRNGKey(10))
 
-pre_optimizer = nnx.Optimizer(prior, optax.adam(1e-3), wrt=nnx.Param)
+import equinox as eqx
+
+pre_optimizer = optax.adam(1e-3)
+pre_opt_state = pre_optimizer.init(eqx.filter(prior, eqx.is_array))
 
 pretrain_losses = []
 n_pretrain_epochs = 20
@@ -92,8 +95,11 @@ def pretrain_loss_fn(prior, x):
 
 
 for epoch in range(n_pretrain_epochs):
-    loss_val, grads = nnx.value_and_grad(pretrain_loss_fn)(prior, batch_train.target)
-    pre_optimizer.update(prior, grads)
+    loss_val, grads = eqx.filter_value_and_grad(pretrain_loss_fn)(
+        prior, batch_train.target
+    )
+    updates, pre_opt_state = pre_optimizer.update(grads, pre_opt_state, prior)
+    prior = eqx.apply_updates(prior, updates)
     pretrain_losses.append(float(loss_val))
 
 print(f"Pre-train final loss: {pretrain_losses[-1]:.6f}")
@@ -104,11 +110,12 @@ print(f"Pre-train final loss: {pretrain_losses[-1]:.6f}")
 # %%
 model_pretrained = FourDVarNet1D(
     state_dim=N, n_time=T, latent_dim=8, hidden_dim=16, n_solver_steps=10,
-    rngs=nnx.Rngs(jax.random.PRNGKey(1)),
+    key=jax.random.PRNGKey(1),
 )
 
-# Copy pre-trained prior weights into the model's prior sub-module
-nnx.update(model_pretrained.prior, nnx.state(prior))
+# Copy pre-trained prior weights into the model's prior sub-module.
+# In Equinox, replace the prior subtree in-place with the pre-trained one.
+model_pretrained = eqx.tree_at(lambda m: m.prior, model_pretrained, prior)
 
 # %% [markdown]
 # ## 4. Stage 2b — Train from scratch (no pre-training)
@@ -116,7 +123,7 @@ nnx.update(model_pretrained.prior, nnx.state(prior))
 # %%
 model_scratch = FourDVarNet1D(
     state_dim=N, n_time=T, latent_dim=8, hidden_dim=16, n_solver_steps=10,
-    rngs=nnx.Rngs(jax.random.PRNGKey(1)),
+    key=jax.random.PRNGKey(1),
 )
 
 # %% [markdown]
@@ -125,7 +132,7 @@ model_scratch = FourDVarNet1D(
 # %%
 n_finetune_epochs = 10
 
-_, metrics_pretrained, _ = vardax.fit(
+model_pretrained, metrics_pretrained, _ = vardax.examples.fit_demo(
     model_pretrained,
     [batch_train],
     n_epochs=n_finetune_epochs,
@@ -133,7 +140,7 @@ _, metrics_pretrained, _ = vardax.fit(
     verbose=False,
 )
 
-_, metrics_scratch, _ = vardax.fit(
+model_scratch, metrics_scratch, _ = vardax.examples.fit_demo(
     model_scratch,
     [batch_train],
     n_epochs=n_finetune_epochs,

--- a/notebooks/08_classical_4dvar_vs_4dvarnet_L63.py
+++ b/notebooks/08_classical_4dvar_vs_4dvarnet_L63.py
@@ -77,9 +77,9 @@ print(f"Test batch shape: {batch_test.input.shape}")
 # convergence trajectory.
 
 # %%
-import flax.nnx as nnx
+# (NNX removed in Epic 0 — vardax is now equinox-native)
 
-prior = BilinAEPrior1D(state_dim=N, latent_dim=8, n_time=T, rngs=nnx.Rngs(jax.random.PRNGKey(5)))
+prior = BilinAEPrior1D(state_dim=N, latent_dim=8, n_time=T, key=jax.random.PRNGKey(5))
 
 
 # Initialise x from masked observations
@@ -116,10 +116,10 @@ print(
 # %%
 model = FourDVarNet1D(
     state_dim=N, n_time=T, latent_dim=8, hidden_dim=16, n_solver_steps=10,
-    rngs=nnx.Rngs(jax.random.PRNGKey(1)),
+    key=jax.random.PRNGKey(1),
 )
 
-_, train_losses, _ = vardax.fit(
+model, train_losses, _ = vardax.examples.fit_demo(
     model,
     [batch_train],
     n_epochs=10,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,13 +34,16 @@ classifiers = [
 dependencies = [
     "jax>=0.5",
     "jaxlib>=0.5",
-    "flax>=0.12",
     "optax>=0.2",
     "jaxtyping>=0.2.28",
     "einops>=0.8",
-    "jaxopt",
     "diffrax>=0.5",
     "equinox>=0.11",
+    "optimistix>=0.1",
+    "lineax>=0.1",
+    "gaussx",
+    "pipekit",
+    "pipekit-cycle",
 ]
 
 [project.urls]
@@ -76,8 +79,15 @@ examples = [
     "loguru>=0.7.2",
     "tqdm>=4.66.0",
 ]
+persist = [
+    "pipekit-jax",
+    "pipekit-experiment",
+]
+train = [
+    "pipekit-train",
+]
 all = [
-    "vardax[data,viz,exp,jlab,examples]",
+    "vardax[data,viz,exp,jlab,examples,persist,train]",
 ]
 
 [build-system]
@@ -209,3 +219,11 @@ source = ["src/vardax"]
 
 [tool.coverage.xml]
 output = "reports/coverage.xml"
+
+[tool.uv.sources]
+gaussx = { git = "https://github.com/jejjohnson/gaussx" }
+pipekit = { git = "https://github.com/jejjohnson/pipekit", subdirectory = "packages/pipekit" }
+pipekit-cycle = { git = "https://github.com/jejjohnson/pipekit", subdirectory = "packages/pipekit-cycle" }
+pipekit-jax = { git = "https://github.com/jejjohnson/pipekit", subdirectory = "packages/pipekit-jax" }
+pipekit-experiment = { git = "https://github.com/jejjohnson/pipekit", subdirectory = "packages/pipekit-experiment" }
+pipekit-train = { git = "https://github.com/jejjohnson/pipekit", subdirectory = "packages/pipekit-train" }

--- a/src/vardax/__init__.py
+++ b/src/vardax/__init__.py
@@ -41,6 +41,8 @@ from vardax._src.model import (
     FourDVarNet2D,
 )
 from vardax._src.models import (
+    IncrementalConfig,
+    IncrementalFourDVar,
     OptimalInterpolation,
     StrongFourDVar,
     ThreeDVar,
@@ -53,6 +55,13 @@ from vardax._src.obs_operators import (
     LinearObs,
     MaskedIdentity,
     MultiInstrumentFusion,
+)
+from vardax._src.posterior import (
+    EnsembleCovariance,
+    GaussianMarkLikelihood,
+    GaussNewtonHessian,
+    LaplaceCovariance,
+    Posterior,
 )
 from vardax._src.priors import (
     BilinAEPrior1D,
@@ -124,6 +133,12 @@ __all__ = [
     "LinearObs",
     "MaskedIdentity",
     "MultiInstrumentFusion",
+    # Posterior adapters (Decision D10)
+    "EnsembleCovariance",
+    "GaussNewtonHessian",
+    "GaussianMarkLikelihood",
+    "LaplaceCovariance",
+    "Posterior",
     # Costs
     "decomposed_loss",
     "obs_cost_1d",
@@ -164,6 +179,8 @@ __all__ = [
     "FourDVarNet1D",
     "FourDVarNet2D",
     # Classical DA methods (Decision D14)
+    "IncrementalConfig",
+    "IncrementalFourDVar",
     "OptimalInterpolation",
     "StrongFourDVar",
     "ThreeDVar",

--- a/src/vardax/__init__.py
+++ b/src/vardax/__init__.py
@@ -62,7 +62,6 @@ from vardax._src.solver import (
 )
 from vardax._src.training import (
     eval_step,
-    fit,
     reconstruction_loss,
     train_loss_fn,
     train_step,
@@ -119,7 +118,6 @@ __all__ = [
     "FourDVarNet2D",
     # Training
     "eval_step",
-    "fit",
     "reconstruction_loss",
     "train_loss_fn",
     "train_step",

--- a/src/vardax/__init__.py
+++ b/src/vardax/__init__.py
@@ -40,6 +40,12 @@ from vardax._src.model import (
     FourDVarNet1D,
     FourDVarNet2D,
 )
+from vardax._src.models import (
+    OptimalInterpolation,
+    StrongFourDVar,
+    ThreeDVar,
+    WeakFourDVar,
+)
 from vardax._src.obs_operators import (
     AveragingKernel,
     InstrumentRegistry,
@@ -157,6 +163,11 @@ __all__ = [
     # Model
     "FourDVarNet1D",
     "FourDVarNet2D",
+    # Classical DA methods (Decision D14)
+    "OptimalInterpolation",
+    "StrongFourDVar",
+    "ThreeDVar",
+    "WeakFourDVar",
     # Training
     "eval_step",
     "reconstruction_loss",

--- a/src/vardax/__init__.py
+++ b/src/vardax/__init__.py
@@ -35,6 +35,14 @@ from vardax._src.model import (
     FourDVarNet1D,
     FourDVarNet2D,
 )
+from vardax._src.obs_operators import (
+    AveragingKernel,
+    InstrumentRegistry,
+    InstrumentSpec,
+    LinearObs,
+    MaskedIdentity,
+    MultiInstrumentFusion,
+)
 from vardax._src.priors import (
     BilinAEPrior1D,
     BilinAEPrior2D,
@@ -44,6 +52,16 @@ from vardax._src.priors import (
     L63Prior,
     L96Prior,
     MLPAEPrior1D,
+)
+from vardax._src.protocols import (
+    AnalysisStep,
+    CostFunction,
+    ForwardModel,
+    GradModulator,
+    Minimiser,
+    ObservationOperator,
+    PosteriorAdapter,
+    Prior,
 )
 from vardax._src.solver import (
     GradMode,
@@ -80,6 +98,22 @@ __all__ = [
     "Batch2DMultivar",
     "LSTMState1D",
     "LSTMState2D",
+    # Protocols (pipekit-cycle + vardax-specific)
+    "AnalysisStep",
+    "CostFunction",
+    "ForwardModel",
+    "GradModulator",
+    "Minimiser",
+    "ObservationOperator",
+    "PosteriorAdapter",
+    "Prior",
+    # Observation operators (Decision D9)
+    "AveragingKernel",
+    "InstrumentRegistry",
+    "InstrumentSpec",
+    "LinearObs",
+    "MaskedIdentity",
+    "MultiInstrumentFusion",
     # Costs
     "decomposed_loss",
     "obs_cost_1d",

--- a/src/vardax/__init__.py
+++ b/src/vardax/__init__.py
@@ -19,6 +19,11 @@ from vardax._src._types import (
     LSTMState1D,
     LSTMState2D,
 )
+from vardax._src.adjoints import (
+    ImplicitAdjoint,
+    OneStepAdjoint,
+    RecursiveCheckpointAdjoint,
+)
 from vardax._src.costs import (
     decomposed_loss,
     obs_cost_1d,
@@ -64,7 +69,6 @@ from vardax._src.protocols import (
     Prior,
 )
 from vardax._src.solver import (
-    GradMode,
     SolverState1D,
     SolverState2D,
     fp_solver_step_1d,
@@ -133,8 +137,11 @@ __all__ = [
     # Gradient modulators
     "ConvLSTMGradMod1D",
     "ConvLSTMGradMod2D",
+    # Adjoints (Decision D15 — replaces v0.1 grad_mode enum)
+    "ImplicitAdjoint",
+    "OneStepAdjoint",
+    "RecursiveCheckpointAdjoint",
     # Solver
-    "GradMode",
     "SolverState1D",
     "SolverState2D",
     "fp_solver_step_1d",

--- a/src/vardax/_src/_types.py
+++ b/src/vardax/_src/_types.py
@@ -1,54 +1,61 @@
-"""Batch and LSTM state type definitions for vardax."""
+"""Batch and LSTM state type definitions for vardax.
 
-from typing import NamedTuple
+All containers are ``eqx.Module``s (not ``NamedTuple``) so they are proper
+JAX pytrees with method support and compose cleanly with
+``eqx.filter_jit`` / ``eqx.filter_vmap`` / ``eqx.filter_value_and_grad``.
+"""
 
+from __future__ import annotations
+
+import equinox as eqx
 import jax.numpy as jnp
 from jaxtyping import Array, Float
 
 
-class Batch1D(NamedTuple):
+class Batch1D(eqx.Module):
     """Batch of 1-D spatiotemporal data.
 
     Attributes:
         input: Observed (masked) input field of shape ``(B, T, N)``.
         mask: Binary observation mask of shape ``(B, T, N)``.
-        target: Ground-truth field of shape ``(B, T, N)``.
+        target: Ground-truth field of shape ``(B, T, N)``. Optional; absent
+            in operational use where only observations are available.
     """
 
     input: Float[Array, "B T N"]
     mask: Float[Array, "B T N"]
-    target: Float[Array, "B T N"]
+    target: Float[Array, "B T N"] | None = None
 
 
-class Batch2D(NamedTuple):
+class Batch2D(eqx.Module):
     """Batch of 2-D spatiotemporal data.
 
     Attributes:
         input: Observed (masked) input field of shape ``(B, T, H, W)``.
         mask: Binary observation mask of shape ``(B, T, H, W)``.
-        target: Ground-truth field of shape ``(B, T, H, W)``.
+        target: Ground-truth field of shape ``(B, T, H, W)``. Optional.
     """
 
     input: Float[Array, "B T H W"]
     mask: Float[Array, "B T H W"]
-    target: Float[Array, "B T H W"]
+    target: Float[Array, "B T H W"] | None = None
 
 
-class Batch2DMultivar(NamedTuple):
+class Batch2DMultivar(eqx.Module):
     """Batch of 2-D multivariate spatiotemporal data.
 
     Attributes:
         input: Observed (masked) input field of shape ``(B, T, C, H, W)``.
         mask: Binary observation mask of shape ``(B, T, C, H, W)``.
-        target: Ground-truth field of shape ``(B, T, C, H, W)``.
+        target: Ground-truth field of shape ``(B, T, C, H, W)``. Optional.
     """
 
     input: Float[Array, "B T C H W"]
     mask: Float[Array, "B T C H W"]
-    target: Float[Array, "B T C H W"]
+    target: Float[Array, "B T C H W"] | None = None
 
 
-class LSTMState1D(NamedTuple):
+class LSTMState1D(eqx.Module):
     """Hidden state for a 1-D ConvLSTM gradient modulator.
 
     Attributes:
@@ -56,8 +63,8 @@ class LSTMState1D(NamedTuple):
         c: Cell state tensor of shape ``(B, H_dim, N)``.
     """
 
-    h: Float[Array, "B H N"]
-    c: Float[Array, "B H N"]
+    h: Float[Array, "B H_dim N"]
+    c: Float[Array, "B H_dim N"]
 
     @classmethod
     def zeros(
@@ -65,15 +72,15 @@ class LSTMState1D(NamedTuple):
         batch_size: int,
         hidden_dim: int,
         seq_len: int,
-    ) -> "LSTMState1D":
-        """Create a zero-initialized LSTM state."""
+    ) -> LSTMState1D:
+        """Create a zero-initialised LSTM state."""
         return cls(
             h=jnp.zeros((batch_size, hidden_dim, seq_len)),
             c=jnp.zeros((batch_size, hidden_dim, seq_len)),
         )
 
 
-class LSTMState2D(NamedTuple):
+class LSTMState2D(eqx.Module):
     """Hidden state for a 2-D ConvLSTM gradient modulator.
 
     Attributes:
@@ -91,8 +98,8 @@ class LSTMState2D(NamedTuple):
         hidden_dim: int,
         height: int,
         width: int,
-    ) -> "LSTMState2D":
-        """Create a zero-initialized LSTM state."""
+    ) -> LSTMState2D:
+        """Create a zero-initialised LSTM state."""
         return cls(
             h=jnp.zeros((batch_size, hidden_dim, height, width)),
             c=jnp.zeros((batch_size, hidden_dim, height, width)),

--- a/src/vardax/_src/adapters/__init__.py
+++ b/src/vardax/_src/adapters/__init__.py
@@ -1,0 +1,9 @@
+"""Adapters for composing vardax with optional ecosystem libraries.
+
+Each submodule corresponds to one upstream library that vardax knows how
+to talk to without taking a hard dependency. The adapter modules are
+only importable when the corresponding optional extra is installed.
+
+- ``vardax.adapters.pipekit_train`` — Loss / training-loop integration with
+  ``pipekit-train`` (install via ``vardax[train]``).
+"""

--- a/src/vardax/_src/adapters/pipekit_train.py
+++ b/src/vardax/_src/adapters/pipekit_train.py
@@ -1,0 +1,77 @@
+"""Integration adapters for ``pipekit-train``.
+
+Provides minimal glue so a vardax model + a ``pipekit_train.Loss``
+implementation compose into a ``pipekit_train.TrainingLoop`` without
+the user reimplementing the inner training step.
+
+Usage
+-----
+
+.. code-block:: python
+
+    from pipekit_jax import JaxModelOp
+    from pipekit_train import MSE, EarlyStopping, Checkpoint, TrainingLoop
+    from vardax import FourDVarNet1D
+    from vardax.adapters.pipekit_train import VardaxReconLoss
+
+    model = FourDVarNet1D(state_dim=N, n_time=T, ..., key=key)
+    model_op = JaxModelOp(model)
+
+    loop = TrainingLoop(
+        dataset=my_dataset,
+        model_op=model_op,
+        loss=VardaxReconLoss(),     # equiv to pipekit_train.MSE on (model(batch), batch.target)
+        callbacks=[EarlyStopping(patience=10), Checkpoint(registry, every_n=100)],
+    )
+    trained_op, state = loop(model_op, TrainerCarryState(...))
+
+The adapter is intentionally thin — ``pipekit_train.MSE()`` already
+works for the standard reconstruction-loss case. ``VardaxReconLoss``
+exists as a convenience that pulls ``batch.target`` out of the vardax
+``Batch*`` container automatically, so callers don't have to unwrap.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import jax.numpy as jnp
+
+if TYPE_CHECKING:
+    from jaxtyping import Array, Float
+
+try:
+    from pipekit import Operator
+except ImportError as exc:  # pragma: no cover
+    raise ImportError(
+        "vardax.adapters.pipekit_train requires the 'train' extra: "
+        "`uv add 'vardax[train]'` or `uv sync --group train`."
+    ) from exc
+
+
+class VardaxReconLoss(Operator):
+    """Reconstruction-loss adapter for ``pipekit_train.TrainingLoop``.
+
+    Equivalent to ``pipekit_train.MSE`` but unwraps the vardax
+    ``Batch*.target`` automatically: the loop hands the loss a
+    ``(prediction, batch)`` pair, and the adapter computes
+    ``mean((prediction - batch.target) ** 2)``.
+
+    Returns ``(loss, {"recon_mse": loss})`` so the training loop sees the
+    standard ``(scalar, aux_dict)`` shape.
+    """
+
+    def _apply(
+        self,
+        predicted: Float[Array, ...],
+        batch: Any,
+    ) -> tuple[Float[Array, ""], dict[str, Float[Array, ""]]]:
+        target = getattr(batch, "target", None)
+        if target is None:
+            raise ValueError(
+                "VardaxReconLoss expects a Batch* with a non-None `target`; "
+                "got batch with target=None. For operational (unlabelled) "
+                "data, evaluate the model directly without a loss adapter."
+            )
+        loss = jnp.mean((predicted - target) ** 2)
+        return loss, {"recon_mse": loss}

--- a/src/vardax/_src/adjoints/__init__.py
+++ b/src/vardax/_src/adjoints/__init__.py
@@ -1,0 +1,52 @@
+"""Adjoint composition for the FourDVarNet inner solver (Decision D15).
+
+vardax does not own adjoint code. Gradients through the inner learned
+solver are composed by selecting an ``optimistix.AbstractAdjoint`` on
+the model:
+
+.. code-block:: python
+
+    import optimistix as optx
+    from vardax.adjoints import OneStepAdjoint
+
+    model = FourDVarNet1D(
+        ...,
+        solver_adjoint=OneStepAdjoint(),  # O(1) memory, Bolte 2023
+    )
+    model = FourDVarNet1D(
+        ...,
+        solver_adjoint=optx.RecursiveCheckpointAdjoint(),  # default
+    )
+    model = FourDVarNet1D(
+        ...,
+        solver_adjoint=optx.ImplicitAdjoint(),  # IFT at fixed point
+    )
+
+The choice replaces the v0.3 ``grad_mode: Literal["unrolled",
+"one_step", "implicit"]`` enum (dropped in this epic, Decision D15).
+
+This module ships:
+
+- :class:`OneStepAdjoint` — Bolte, Pauwels & Vaiter (NeurIPS 2023);
+  the only vardax-owned adjoint. Subclasses
+  ``optimistix.AbstractAdjoint`` and targets upstream contribution.
+- Re-exports ``optimistix.RecursiveCheckpointAdjoint`` and
+  ``optimistix.ImplicitAdjoint`` for one-stop import.
+"""
+
+from __future__ import annotations
+
+from optimistix import (
+    AbstractAdjoint,
+    ImplicitAdjoint,
+    RecursiveCheckpointAdjoint,
+)
+
+from .one_step import OneStepAdjoint
+
+__all__ = [
+    "AbstractAdjoint",
+    "ImplicitAdjoint",
+    "OneStepAdjoint",
+    "RecursiveCheckpointAdjoint",
+]

--- a/src/vardax/_src/adjoints/one_step.py
+++ b/src/vardax/_src/adjoints/one_step.py
@@ -1,0 +1,91 @@
+"""One-step differentiation of iterative algorithms (Bolte et al., 2023).
+
+vardax-owned ``optimistix.AbstractAdjoint`` subclass implementing the
+one-step differentiation strategy from
+
+    Bolte, Pauwels & Vaiter (2023). One-step differentiation of
+    iterative algorithms. NeurIPS 36. arXiv:2305.13768
+
+The strategy: run ``K - 1`` iterations of the inner solver with
+``jax.lax.stop_gradient`` applied to the iterate, then one
+differentiable step. Memory is O(1) (matching ``ImplicitAdjoint``)
+without requiring strict convergence to a fixed point.
+
+The plan (Decision D6, D15) is to contribute this upstream to
+``optimistix`` once stable. Until then, it lives in vardax. The class
+is implemented as a marker / strategy selector for the
+``FourDVarNet`` inner solver — the actual one-step dispatch lives in
+``vardax._src.solver.one_step_solve_4dvarnet_*``. The model's
+``__call__`` uses ``isinstance(model.solver_adjoint, OneStepAdjoint)``
+to pick the path.
+
+Because optimistix's ``minimise`` is not the use site for vardax's
+custom learned solver, the ``apply()`` method here is a no-op stub
+(raises ``NotImplementedError`` if hit). This will fill in when the
+adjoint is generalised for upstream contribution.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+from jaxtyping import Array, PyTree
+import optimistix as optx
+
+
+class OneStepAdjoint(optx.AbstractAdjoint):
+    """One-step differentiation (Bolte et al., 2023).
+
+    Run ``K - 1`` warmup iterations of the inner solver with
+    ``jax.lax.stop_gradient``, then one differentiable step. Gives
+    O(1) memory and is exact at the fixed point of the inner
+    iteration.
+
+    Use as the ``solver_adjoint`` argument to ``FourDVarNet1D`` /
+    ``FourDVarNet2D``:
+
+    .. code-block:: python
+
+        from vardax.adjoints import OneStepAdjoint
+
+        model = FourDVarNet1D(
+            state_dim=N, n_time=T, ...,
+            solver_adjoint=OneStepAdjoint(),
+            key=key,
+        )
+
+    References:
+        Bolte, J., Pauwels, E. & Vaiter, S. (2023). One-step
+        differentiation of iterative algorithms. NeurIPS 36.
+        `arXiv:2305.13768 <https://arxiv.org/abs/2305.13768>`_.
+    """
+
+    def apply(
+        self,
+        primal_fn: Callable,
+        rewrite_fn: Callable,
+        inputs: PyTree,
+        tags: frozenset[object],
+    ) -> PyTree[Array]:
+        """Not used by vardax's custom learned solver — dispatch happens
+        in ``vardax._src.solver`` via ``isinstance`` on the adjoint type.
+
+        Implementing this method for upstream ``optimistix.minimise``
+        compatibility is tracked under the planned upstream
+        contribution (Decision D6).
+        """
+        raise NotImplementedError(
+            "OneStepAdjoint is currently a marker / strategy selector for the "
+            "FourDVarNet inner solver. Generic apply() support for "
+            "optimistix.minimise is planned as part of the upstream "
+            "contribution. Use it via FourDVarNet*(solver_adjoint=OneStepAdjoint())."
+        )
+
+    def __repr__(self) -> str:  # pragma: no cover - cosmetic
+        return "OneStepAdjoint()"
+
+
+def _is_one_step_adjoint(adjoint: Any) -> bool:
+    """Type-narrowing helper for solver dispatch."""
+    return isinstance(adjoint, OneStepAdjoint)

--- a/src/vardax/_src/examples.py
+++ b/src/vardax/_src/examples.py
@@ -1,0 +1,76 @@
+"""Notebook-demo helpers (not part of the library API).
+
+These helpers exist for the tutorial notebooks under ``notebooks/``.
+Production code should compose ``train_step`` (Layer 0 primitive)
+with ``pipekit-train`` (``[train]`` extra) or with any other training
+framework — vardax does not own training loops.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import equinox as eqx
+import jax.numpy as jnp
+import optax
+
+from ._types import Batch1D, Batch2D
+from .training import eval_step, train_step
+
+
+def fit_demo(
+    model: Any,
+    train_batches: list[Batch1D | Batch2D],
+    *,
+    lr: float = 1e-3,
+    n_epochs: int = 10,
+    val_batches: list[Batch1D | Batch2D] | None = None,
+    verbose: bool = True,
+) -> tuple[Any, list[float], list[float]]:
+    """Minimal notebook-demo training loop.
+
+    Composes ``optax.adam`` + ``vardax.train_step`` inline. Not a library
+    API — exists for pedagogical use in ``notebooks/``. For production
+    training, use ``pipekit-train.TrainingLoop`` via
+    ``vardax.adapters.pipekit_train``.
+
+    Args:
+        model: Equinox module to train.
+        train_batches: List of training batches.
+        lr: Adam learning rate.
+        n_epochs: Number of epochs.
+        val_batches: Optional validation batches.
+        verbose: Print per-epoch losses.
+
+    Returns:
+        Tuple of (trained model, per-epoch mean train losses, per-epoch
+        mean val losses (NaN when ``val_batches`` is None)).
+    """
+    optimizer = optax.adam(lr)
+    opt_state = optimizer.init(eqx.filter(model, eqx.is_array))
+
+    train_history: list[float] = []
+    val_history: list[float] = []
+
+    for epoch in range(n_epochs):
+        epoch_train_losses: list[float] = []
+        for batch in train_batches:
+            model, opt_state, loss = train_step(model, batch, optimizer, opt_state)
+            epoch_train_losses.append(float(loss))
+        mean_train = float(jnp.mean(jnp.array(epoch_train_losses)))
+        train_history.append(mean_train)
+
+        mean_val = float("nan")
+        if val_batches is not None:
+            epoch_val_losses = [float(eval_step(model, b)) for b in val_batches]
+            mean_val = float(jnp.mean(jnp.array(epoch_val_losses)))
+        val_history.append(mean_val)
+
+        if verbose:
+            print(
+                f"epoch {epoch + 1}/{n_epochs} — "
+                f"train loss: {mean_train:.6f}"
+                + (f"  val loss: {mean_val:.6f}" if val_batches else "")
+            )
+
+    return model, train_history, val_history

--- a/src/vardax/_src/grad_mod.py
+++ b/src/vardax/_src/grad_mod.py
@@ -1,35 +1,42 @@
-"""ConvLSTM gradient modulators for 4DVarNet.
+"""ConvLSTM gradient modulators for FourDVarNet.
 
 The gradient modulator takes the current gradient of the variational cost
 (with respect to the state) and the current LSTM hidden state, and outputs
 a modulated gradient update plus the new LSTM state.
+
+Implemented in Equinox; convolutions are channels-first
+(`eqx.nn.Conv1d` / `Conv2d`), with `jax.vmap` applied over the leading
+batch axis.
 """
 
 from __future__ import annotations
 
-from flax import nnx
+import equinox as eqx
 import jax
 import jax.numpy as jnp
-from jaxtyping import Array, Float
+from jaxtyping import Array, Float, PRNGKeyArray
 
 from ._types import LSTMState1D, LSTMState2D
 
-# ---------------------------------------------------------------------------
-# 1-D ConvLSTM gradient modulator
-# ---------------------------------------------------------------------------
 
-
-class ConvLSTMGradMod1D(nnx.Module):
+class ConvLSTMGradMod1D(eqx.Module):
     """1-D ConvLSTM-based gradient modulator.
 
     Accepts the concatenation of the current state and its gradient as input
     and produces a modulated gradient update (and updated LSTM state).
 
     Attributes:
-        state_channels: Number of channels in the state / gradient.
+        state_channels: Number of channels in the state / gradient (``T``).
         hidden_dim: Number of hidden channels in the LSTM.
         kernel_size: 1-D convolution kernel size.
     """
+
+    state_channels: int = eqx.field(static=True)
+    hidden_dim: int = eqx.field(static=True)
+    kernel_size: int = eqx.field(static=True)
+    _gates_input_conv: eqx.nn.Conv1d
+    _gates_hidden_conv: eqx.nn.Conv1d
+    _output_conv: eqx.nn.Conv1d
 
     def __init__(
         self,
@@ -37,23 +44,33 @@ class ConvLSTMGradMod1D(nnx.Module):
         hidden_dim: int,
         kernel_size: int = 3,
         *,
-        rngs: nnx.Rngs,
+        key: PRNGKeyArray,
     ) -> None:
         self.state_channels = state_channels
         self.hidden_dim = hidden_dim
-        ksize = (kernel_size,)
-        self._gates_input_conv = nnx.Conv(
-            2 * state_channels,
-            4 * hidden_dim,
-            kernel_size=ksize,
-            padding="SAME",
-            rngs=rngs,
+        self.kernel_size = kernel_size
+        k1, k2, k3 = jax.random.split(key, 3)
+        pad = kernel_size // 2
+        self._gates_input_conv = eqx.nn.Conv1d(
+            in_channels=2 * state_channels,
+            out_channels=4 * hidden_dim,
+            kernel_size=kernel_size,
+            padding=pad,
+            key=k1,
         )
-        self._gates_hidden_conv = nnx.Conv(
-            hidden_dim, 4 * hidden_dim, kernel_size=ksize, padding="SAME", rngs=rngs
+        self._gates_hidden_conv = eqx.nn.Conv1d(
+            in_channels=hidden_dim,
+            out_channels=4 * hidden_dim,
+            kernel_size=kernel_size,
+            padding=pad,
+            key=k2,
         )
-        self._output_conv = nnx.Conv(
-            hidden_dim, state_channels, kernel_size=ksize, padding="SAME", rngs=rngs
+        self._output_conv = eqx.nn.Conv1d(
+            in_channels=hidden_dim,
+            out_channels=state_channels,
+            kernel_size=kernel_size,
+            padding=pad,
+            key=k3,
         )
 
     def __call__(
@@ -67,50 +84,38 @@ class ConvLSTMGradMod1D(nnx.Module):
         Args:
             grad: Gradient of variational cost w.r.t. state, shape ``(B, T, N)``.
             state: Current state estimate, shape ``(B, T, N)``.
-            lstm_state: Current LSTM hidden/cell state.
+            lstm_state: Current LSTM hidden/cell state with hidden_dim channels.
 
         Returns:
             Tuple of (modulated gradient update, new LSTM state).
         """
-        # Concatenate along time axis and reshape to (B, N, C) for conv
-        # Treat T as channels for 1-D spatial conv over N
-        x = jnp.concatenate([grad, state], axis=1)  # (B, 2T, N)
-        x = jnp.transpose(x, (0, 2, 1))  # (B, N, 2T)
+        # eqx.nn.Conv1d operates on (channels, spatial). Our arrays are already
+        # (B, channels, spatial) with T=channels for grad/state and H=channels
+        # for the LSTM state — vmap over the leading batch dim.
 
-        h = jnp.transpose(lstm_state.h, (0, 2, 1))  # (B, N, H)
-        c = lstm_state.c
+        def _forward(
+            grad_i: Float[Array, "T N"],
+            state_i: Float[Array, "T N"],
+            h_i: Float[Array, "H N"],
+            c_i: Float[Array, "H N"],
+        ) -> tuple[Float[Array, "T N"], Float[Array, "H N"], Float[Array, "H N"]]:
+            x = jnp.concatenate([grad_i, state_i], axis=0)  # (2T, N)
+            gates = self._gates_input_conv(x) + self._gates_hidden_conv(h_i)
+            i, f, g, o = jnp.split(gates, 4, axis=0)
+            i = jax.nn.sigmoid(i)
+            f = jax.nn.sigmoid(f)
+            g = jnp.tanh(g)
+            o = jax.nn.sigmoid(o)
+            c_new = f * c_i + i * g
+            h_new = o * jnp.tanh(c_new)
+            out = self._output_conv(h_new)
+            return out, h_new, c_new
 
-        # LSTM gates (spatial convolution over N)
-        gates_input = self._gates_input_conv(x)
-        gates_hidden = self._gates_hidden_conv(h)
-        gates = gates_input + gates_hidden  # (B, N, 4H)
-
-        i, f, g, o = jnp.split(gates, 4, axis=-1)
-        i = jax.nn.sigmoid(i)
-        f = jax.nn.sigmoid(f)
-        g = jnp.tanh(g)
-        o = jax.nn.sigmoid(o)
-
-        c_new = f * jnp.transpose(c, (0, 2, 1)) + i * g
-        h_new = o * jnp.tanh(c_new)
-
-        # Output projection: from (B, N, H) back to (B, T, N)
-        out = self._output_conv(h_new)  # (B, N, state_channels)
-        out = jnp.transpose(out, (0, 2, 1))  # (B, T, N)
-
-        new_lstm = LSTMState1D(
-            h=jnp.transpose(h_new, (0, 2, 1)),
-            c=jnp.transpose(c_new, (0, 2, 1)),
-        )
-        return out, new_lstm
+        out, h_new, c_new = jax.vmap(_forward)(grad, state, lstm_state.h, lstm_state.c)
+        return out, LSTMState1D(h=h_new, c=c_new)
 
 
-# ---------------------------------------------------------------------------
-# 2-D ConvLSTM gradient modulator
-# ---------------------------------------------------------------------------
-
-
-class ConvLSTMGradMod2D(nnx.Module):
+class ConvLSTMGradMod2D(eqx.Module):
     """2-D ConvLSTM-based gradient modulator.
 
     Attributes:
@@ -119,29 +124,46 @@ class ConvLSTMGradMod2D(nnx.Module):
         kernel_size: 2-D convolution kernel size.
     """
 
+    state_channels: int = eqx.field(static=True)
+    hidden_dim: int = eqx.field(static=True)
+    kernel_size: int = eqx.field(static=True)
+    _gates_input_conv: eqx.nn.Conv2d
+    _gates_hidden_conv: eqx.nn.Conv2d
+    _output_conv: eqx.nn.Conv2d
+
     def __init__(
         self,
         state_channels: int,
         hidden_dim: int,
         kernel_size: int = 3,
         *,
-        rngs: nnx.Rngs,
+        key: PRNGKeyArray,
     ) -> None:
         self.state_channels = state_channels
         self.hidden_dim = hidden_dim
-        ksize = (kernel_size, kernel_size)
-        self._gates_input_conv = nnx.Conv(
-            2 * state_channels,
-            4 * hidden_dim,
-            kernel_size=ksize,
-            padding="SAME",
-            rngs=rngs,
+        self.kernel_size = kernel_size
+        k1, k2, k3 = jax.random.split(key, 3)
+        pad = kernel_size // 2
+        self._gates_input_conv = eqx.nn.Conv2d(
+            in_channels=2 * state_channels,
+            out_channels=4 * hidden_dim,
+            kernel_size=kernel_size,
+            padding=pad,
+            key=k1,
         )
-        self._gates_hidden_conv = nnx.Conv(
-            hidden_dim, 4 * hidden_dim, kernel_size=ksize, padding="SAME", rngs=rngs
+        self._gates_hidden_conv = eqx.nn.Conv2d(
+            in_channels=hidden_dim,
+            out_channels=4 * hidden_dim,
+            kernel_size=kernel_size,
+            padding=pad,
+            key=k2,
         )
-        self._output_conv = nnx.Conv(
-            hidden_dim, state_channels, kernel_size=ksize, padding="SAME", rngs=rngs
+        self._output_conv = eqx.nn.Conv2d(
+            in_channels=hidden_dim,
+            out_channels=state_channels,
+            kernel_size=kernel_size,
+            padding=pad,
+            key=k3,
         )
 
     def __call__(
@@ -160,32 +182,28 @@ class ConvLSTMGradMod2D(nnx.Module):
         Returns:
             Tuple of (modulated gradient update, new LSTM state).
         """
-        # Reshape to (B, H, W, C) for Conv
-        x = jnp.concatenate([grad, state], axis=1)  # (B, 2T, H, W)
-        x = jnp.transpose(x, (0, 2, 3, 1))  # (B, H, W, 2T)
 
-        hh = jnp.transpose(lstm_state.h, (0, 2, 3, 1))  # (B, H, W, H_dim)
-        cc = jnp.transpose(lstm_state.c, (0, 2, 3, 1))  # (B, H, W, H_dim)
+        def _forward(
+            grad_i: Float[Array, "T H W"],
+            state_i: Float[Array, "T H W"],
+            h_i: Float[Array, "H_dim H W"],
+            c_i: Float[Array, "H_dim H W"],
+        ) -> tuple[
+            Float[Array, "T H W"],
+            Float[Array, "H_dim H W"],
+            Float[Array, "H_dim H W"],
+        ]:
+            x = jnp.concatenate([grad_i, state_i], axis=0)  # (2T, H, W)
+            gates = self._gates_input_conv(x) + self._gates_hidden_conv(h_i)
+            i, f, g, o = jnp.split(gates, 4, axis=0)
+            i = jax.nn.sigmoid(i)
+            f = jax.nn.sigmoid(f)
+            g = jnp.tanh(g)
+            o = jax.nn.sigmoid(o)
+            c_new = f * c_i + i * g
+            h_new = o * jnp.tanh(c_new)
+            out = self._output_conv(h_new)
+            return out, h_new, c_new
 
-        gates_input = self._gates_input_conv(x)
-        gates_hidden = self._gates_hidden_conv(hh)
-        gates = gates_input + gates_hidden
-
-        i, f, g, o = jnp.split(gates, 4, axis=-1)
-        i = jax.nn.sigmoid(i)
-        f = jax.nn.sigmoid(f)
-        g = jnp.tanh(g)
-        o = jax.nn.sigmoid(o)
-
-        c_new = f * cc + i * g
-        h_new = o * jnp.tanh(c_new)
-
-        # Output projection back to (B, T, H, W)
-        out = self._output_conv(h_new)  # (B, H, W, state_channels)
-        out = jnp.transpose(out, (0, 3, 1, 2))  # (B, T, H, W)
-
-        new_lstm = LSTMState2D(
-            h=jnp.transpose(h_new, (0, 3, 1, 2)),
-            c=jnp.transpose(c_new, (0, 3, 1, 2)),
-        )
-        return out, new_lstm
+        out, h_new, c_new = jax.vmap(_forward)(grad, state, lstm_state.h, lstm_state.c)
+        return out, LSTMState2D(h=h_new, c=c_new)

--- a/src/vardax/_src/model.py
+++ b/src/vardax/_src/model.py
@@ -13,6 +13,8 @@ argument are supported, but ``grad_mode`` is removed in Epic 3.
 
 from __future__ import annotations
 
+from typing import Any
+
 import equinox as eqx
 import jax
 import jax.numpy as jnp
@@ -147,6 +149,35 @@ class FourDVarNet1D(eqx.Module):
             batch, self.prior, n_fp_steps=self.n_solver_steps
         )
 
+    def as_analysis_step(self) -> _FourDVarNet1DAnalysisStep:
+        """Adapt to ``pipekit_cycle.AnalysisStep``.
+
+        Returns a callable matching
+        ``(forecast, obs, *, obs_op, obs_err_cov) -> analysis`` so the
+        model can drop into ``pipekit_cycle.DACycle`` /
+        ``SmootherCycle`` directly. Decision D8.
+        """
+        return _FourDVarNet1DAnalysisStep(self)
+
+
+class _FourDVarNet1DAnalysisStep(eqx.Module):
+    """``pipekit_cycle.AnalysisStep`` adapter for ``FourDVarNet1D``."""
+
+    model: FourDVarNet1D
+
+    def __call__(
+        self,
+        forecast: Float[Array, "B T N"],
+        obs: Float[Array, "B T N"],
+        *,
+        obs_op: Any,  # pipekit_cycle.ObservationOperator
+        obs_err_cov: Any,
+    ) -> Float[Array, "B T N"]:
+        mask = jnp.where(jnp.isfinite(obs), 1.0, 0.0)
+        obs_clean = jnp.nan_to_num(obs)
+        batch = Batch1D(input=obs_clean, mask=mask, target=None)
+        return self.model(batch)
+
 
 class FourDVarNet2D(eqx.Module):
     """End-to-end 4DVarNet model for 2-D spatiotemporal reconstruction.
@@ -248,3 +279,26 @@ class FourDVarNet2D(eqx.Module):
         raise NotImplementedError(
             "Implicit differentiation for FourDVarNet2D is not yet implemented."
         )
+
+    def as_analysis_step(self) -> _FourDVarNet2DAnalysisStep:
+        """Adapt to ``pipekit_cycle.AnalysisStep`` (Decision D8)."""
+        return _FourDVarNet2DAnalysisStep(self)
+
+
+class _FourDVarNet2DAnalysisStep(eqx.Module):
+    """``pipekit_cycle.AnalysisStep`` adapter for ``FourDVarNet2D``."""
+
+    model: FourDVarNet2D
+
+    def __call__(
+        self,
+        forecast: Float[Array, "B T H W"],
+        obs: Float[Array, "B T H W"],
+        *,
+        obs_op: Any,  # pipekit_cycle.ObservationOperator
+        obs_err_cov: Any,
+    ) -> Float[Array, "B T H W"]:
+        mask = jnp.where(jnp.isfinite(obs), 1.0, 0.0)
+        obs_clean = jnp.nan_to_num(obs)
+        batch = Batch2D(input=obs_clean, mask=mask, target=None)
+        return self.model(batch)

--- a/src/vardax/_src/model.py
+++ b/src/vardax/_src/model.py
@@ -1,15 +1,22 @@
 """End-to-end 4DVarNet models.
 
-Composes the prior, gradient modulator, and solver into a single Flax NNX
-module that can be trained end-to-end.
+Composes the prior, gradient modulator, and solver into a single
+``eqx.Module`` that can be trained end-to-end via ``optax`` +
+``eqx.filter_value_and_grad``.
+
+In v0.4, the differentiation strategy is selected via an
+``optimistix.AbstractAdjoint`` slot rather than a ``grad_mode`` enum
+(Decision D15). For backward compatibility during the equinox migration
+window, both the old ``grad_mode`` argument and the new ``solver_adjoint``
+argument are supported, but ``grad_mode`` is removed in Epic 3.
 """
 
 from __future__ import annotations
 
-from flax import nnx
+import equinox as eqx
 import jax
 import jax.numpy as jnp
-from jaxtyping import Array, Float
+from jaxtyping import Array, Float, PRNGKeyArray
 
 from ._types import Batch1D, Batch2D, LSTMState1D, LSTMState2D
 from .grad_mod import ConvLSTMGradMod1D, ConvLSTMGradMod2D
@@ -17,7 +24,7 @@ from .priors import BilinAEPrior1D, BilinAEPrior2D
 from .solver import GradMode
 
 
-class FourDVarNet1D(nnx.Module):
+class FourDVarNet1D(eqx.Module):
     """End-to-end 4DVarNet model for 1-D spatiotemporal reconstruction.
 
     The model minimises the variational cost
@@ -31,20 +38,25 @@ class FourDVarNet1D(nnx.Module):
     ConvLSTM.
 
     Attributes:
-        state_dim: Spatial dimension ``N`` of the state.
-        n_time: Number of time steps ``T``.
-        latent_dim: Latent dimension of the bilinear autoencoder prior.
-        hidden_dim: Hidden dimension of the ConvLSTM gradient modulator.
         n_solver_steps: Number of solver iterations to unroll.
         alpha: Gradient step-size.
         prior_weight: Weight :math:`\\lambda` for the prior cost term.
-        grad_mode: Differentiation and solver strategy (``"unrolled"``,
-            ``"one_step"``, or ``"implicit"``).  In ``"implicit"`` mode the
-            forward pass uses a fixed-point projection based only on the
-            prior; the ConvLSTM gradient modulator, ``alpha``, and
-            ``prior_weight`` are not used in the solver, and only the
-            implicit fixed point is differentiated through.
+        grad_mode: Differentiation strategy (``"unrolled"``, ``"one_step"``,
+            or ``"implicit"``). In ``"implicit"`` mode the forward pass uses
+            a fixed-point projection based only on the prior; the ConvLSTM
+            gradient modulator, ``alpha``, and ``prior_weight`` are not used
+            in the solver, and only the implicit fixed point is
+            differentiated through.
+        prior: BilinAEPrior1D learned prior.
+        grad_mod: ConvLSTMGradMod1D learned gradient modulator.
     """
+
+    n_solver_steps: int = eqx.field(static=True)
+    alpha: float = eqx.field(static=True)
+    prior_weight: float = eqx.field(static=True)
+    grad_mode: GradMode = eqx.field(static=True)
+    prior: BilinAEPrior1D
+    grad_mod: ConvLSTMGradMod1D
 
     def __init__(
         self,
@@ -57,22 +69,23 @@ class FourDVarNet1D(nnx.Module):
         prior_weight: float = 1.0,
         grad_mode: GradMode = "unrolled",
         *,
-        rngs: nnx.Rngs,
+        key: PRNGKeyArray,
     ) -> None:
         self.n_solver_steps = n_solver_steps
         self.alpha = alpha
         self.prior_weight = prior_weight
         self.grad_mode = grad_mode
+        k_prior, k_grad = jax.random.split(key)
         self.prior = BilinAEPrior1D(
             state_dim=state_dim,
             latent_dim=latent_dim,
             n_time=n_time,
-            rngs=rngs,
+            key=k_prior,
         )
         self.grad_mod = ConvLSTMGradMod1D(
             state_channels=n_time,
             hidden_dim=hidden_dim,
-            rngs=rngs,
+            key=k_grad,
         )
 
     def __call__(self, batch: Batch1D) -> Float[Array, "B T N"]:
@@ -127,9 +140,7 @@ class FourDVarNet1D(nnx.Module):
 
     def _call_implicit(self, batch: Batch1D) -> Float[Array, "B T N"]:
         # Uses the fixed-point projection solver (prior only; grad_mod and
-        # alpha are not used in this mode).  A full implicit-differentiation
-        # implementation that incorporates the gradient modulator requires
-        # jaxopt or a similar fixed-point solver library.
+        # alpha are not used in this mode).
         from .solver import solve_4dvarnet_1d_fixedpoint
 
         return solve_4dvarnet_1d_fixedpoint(
@@ -137,26 +148,26 @@ class FourDVarNet1D(nnx.Module):
         )
 
 
-class FourDVarNet2D(nnx.Module):
+class FourDVarNet2D(eqx.Module):
     """End-to-end 4DVarNet model for 2-D spatiotemporal reconstruction.
 
     Attributes:
-        n_time: Number of time steps ``T``.
-        height: Spatial height ``H``.
-        width: Spatial width ``W``.
-        latent_dim: Latent dimension of the bilinear autoencoder prior.
-        hidden_dim: Hidden dimension of the ConvLSTM gradient modulator.
         n_solver_steps: Number of solver iterations to unroll.
         alpha: Gradient step-size.
         prior_weight: Weight for the prior cost term.
-        grad_mode: Differentiation and solver strategy (``"unrolled"``,
-            ``"one_step"``, or ``"implicit"``).  In ``"implicit"`` mode the
-            forward pass uses a fixed-point projection based only on the
-            prior; the ConvLSTM gradient modulator, ``alpha``, and
-            ``prior_weight`` are not used in the solver, and only the
-            implicit fixed point is differentiated through.  Note that
-            ``"implicit"`` is not yet implemented for 2-D models.
+        grad_mode: Differentiation strategy (``"unrolled"``, ``"one_step"``,
+            or ``"implicit"``). ``"implicit"`` is not yet implemented for
+            2-D models.
+        prior: BilinAEPrior2D learned prior.
+        grad_mod: ConvLSTMGradMod2D learned gradient modulator.
     """
+
+    n_solver_steps: int = eqx.field(static=True)
+    alpha: float = eqx.field(static=True)
+    prior_weight: float = eqx.field(static=True)
+    grad_mode: GradMode = eqx.field(static=True)
+    prior: BilinAEPrior2D
+    grad_mod: ConvLSTMGradMod2D
 
     def __init__(
         self,
@@ -170,34 +181,28 @@ class FourDVarNet2D(nnx.Module):
         prior_weight: float = 1.0,
         grad_mode: GradMode = "unrolled",
         *,
-        rngs: nnx.Rngs,
+        key: PRNGKeyArray,
     ) -> None:
         self.n_solver_steps = n_solver_steps
         self.alpha = alpha
         self.prior_weight = prior_weight
         self.grad_mode = grad_mode
+        k_prior, k_grad = jax.random.split(key)
         self.prior = BilinAEPrior2D(
             latent_dim=latent_dim,
             n_time=n_time,
             height=height,
             width=width,
-            rngs=rngs,
+            key=k_prior,
         )
         self.grad_mod = ConvLSTMGradMod2D(
             state_channels=n_time,
             hidden_dim=hidden_dim,
-            rngs=rngs,
+            key=k_grad,
         )
 
     def __call__(self, batch: Batch2D) -> Float[Array, "B T H W"]:
-        """Run the solver and return the final state estimate.
-
-        Args:
-            batch: Input batch with ``input``, ``mask``, and ``target`` fields.
-
-        Returns:
-            Reconstructed state of shape ``(B, T, H, W)``.
-        """
+        """Run the solver and return the final state estimate."""
         if self.grad_mode == "unrolled":
             return self._call_unrolled(batch)
         elif self.grad_mode == "one_step":
@@ -240,9 +245,6 @@ class FourDVarNet2D(nnx.Module):
         )
 
     def _call_implicit(self, batch: Batch2D) -> Float[Array, "B T H W"]:
-        # Note: the fixed-point projection solver uses only the prior (no
-        # gradient modulator).  A full implicit-diff implementation with a
-        # gradient-modulated solver requires jaxopt.
         raise NotImplementedError(
             "Implicit differentiation for FourDVarNet2D is not yet implemented."
         )

--- a/src/vardax/_src/model.py
+++ b/src/vardax/_src/model.py
@@ -4,11 +4,17 @@ Composes the prior, gradient modulator, and solver into a single
 ``eqx.Module`` that can be trained end-to-end via ``optax`` +
 ``eqx.filter_value_and_grad``.
 
-In v0.4, the differentiation strategy is selected via an
-``optimistix.AbstractAdjoint`` slot rather than a ``grad_mode`` enum
-(Decision D15). For backward compatibility during the equinox migration
-window, both the old ``grad_mode`` argument and the new ``solver_adjoint``
-argument are supported, but ``grad_mode`` is removed in Epic 3.
+In v0.4 the differentiation strategy is selected via a
+``solver_adjoint: optimistix.AbstractAdjoint`` constructor slot
+(Decision D15). The ``grad_mode`` enum from v0.1.x is gone:
+
+- ``optimistix.RecursiveCheckpointAdjoint()`` → unrolled backprop with
+  recursive checkpointing (the default)
+- ``vardax.adjoints.OneStepAdjoint()`` → Bolte et al. 2023, O(1) memory
+- ``optimistix.ImplicitAdjoint()`` → fixed-point projection + IFT
+
+The dispatch in ``FourDVarNet*.__call__`` checks the adjoint's type
+to pick the corresponding inner-solver path.
 """
 
 from __future__ import annotations
@@ -19,36 +25,40 @@ import equinox as eqx
 import jax
 import jax.numpy as jnp
 from jaxtyping import Array, Float, PRNGKeyArray
+import optimistix as optx
 
 from ._types import Batch1D, Batch2D, LSTMState1D, LSTMState2D
+from .adjoints import OneStepAdjoint
 from .grad_mod import ConvLSTMGradMod1D, ConvLSTMGradMod2D
 from .priors import BilinAEPrior1D, BilinAEPrior2D
-from .solver import GradMode
+
+
+def _default_adjoint() -> optx.AbstractAdjoint:
+    """Default adjoint for the FourDVarNet inner solver."""
+    return optx.RecursiveCheckpointAdjoint()
 
 
 class FourDVarNet1D(eqx.Module):
     """End-to-end 4DVarNet model for 1-D spatiotemporal reconstruction.
 
-    The model minimises the variational cost
+    Minimises the variational cost
 
     .. math::
 
         J(x) = \\|\\mathbf{m} \\odot (x - y)\\|^2 + \\lambda \\|x - \\varphi(x)\\|^2
 
-    using ``n_solver_steps`` learned gradient steps, where :math:`\\varphi` is
-    the bilinear autoencoder prior and the gradient steps are modulated by a
-    ConvLSTM.
+    using ``n_solver_steps`` learned gradient steps modulated by a ConvLSTM,
+    with the differentiation strategy selected by ``solver_adjoint``.
 
     Attributes:
         n_solver_steps: Number of solver iterations to unroll.
         alpha: Gradient step-size.
         prior_weight: Weight :math:`\\lambda` for the prior cost term.
-        grad_mode: Differentiation strategy (``"unrolled"``, ``"one_step"``,
-            or ``"implicit"``). In ``"implicit"`` mode the forward pass uses
-            a fixed-point projection based only on the prior; the ConvLSTM
-            gradient modulator, ``alpha``, and ``prior_weight`` are not used
-            in the solver, and only the implicit fixed point is
-            differentiated through.
+        solver_adjoint: ``optimistix.AbstractAdjoint`` selecting the
+            differentiation strategy. Defaults to
+            ``RecursiveCheckpointAdjoint`` (standard backprop). Use
+            ``OneStepAdjoint()`` for O(1)-memory training (Bolte et al.
+            2023) or ``ImplicitAdjoint()`` for fixed-point projection.
         prior: BilinAEPrior1D learned prior.
         grad_mod: ConvLSTMGradMod1D learned gradient modulator.
     """
@@ -56,7 +66,7 @@ class FourDVarNet1D(eqx.Module):
     n_solver_steps: int = eqx.field(static=True)
     alpha: float = eqx.field(static=True)
     prior_weight: float = eqx.field(static=True)
-    grad_mode: GradMode = eqx.field(static=True)
+    solver_adjoint: optx.AbstractAdjoint = eqx.field(static=True)
     prior: BilinAEPrior1D
     grad_mod: ConvLSTMGradMod1D
 
@@ -69,14 +79,14 @@ class FourDVarNet1D(eqx.Module):
         n_solver_steps: int = 15,
         alpha: float = 0.2,
         prior_weight: float = 1.0,
-        grad_mode: GradMode = "unrolled",
+        solver_adjoint: optx.AbstractAdjoint | None = None,
         *,
         key: PRNGKeyArray,
     ) -> None:
         self.n_solver_steps = n_solver_steps
         self.alpha = alpha
         self.prior_weight = prior_weight
-        self.grad_mode = grad_mode
+        self.solver_adjoint = solver_adjoint or _default_adjoint()
         k_prior, k_grad = jax.random.split(key)
         self.prior = BilinAEPrior1D(
             state_dim=state_dim,
@@ -93,20 +103,16 @@ class FourDVarNet1D(eqx.Module):
     def __call__(self, batch: Batch1D) -> Float[Array, "B T N"]:
         """Run the solver and return the final state estimate.
 
-        Args:
-            batch: Input batch with ``input``, ``mask``, and ``target`` fields.
-
-        Returns:
-            Reconstructed state of shape ``(B, T, N)``.
+        Dispatches on ``solver_adjoint`` to pick the differentiation
+        path.
         """
-        if self.grad_mode == "unrolled":
-            return self._call_unrolled(batch)
-        elif self.grad_mode == "one_step":
+        if isinstance(self.solver_adjoint, OneStepAdjoint):
             return self._call_one_step(batch)
-        elif self.grad_mode == "implicit":
+        if isinstance(self.solver_adjoint, optx.ImplicitAdjoint):
             return self._call_implicit(batch)
-        else:
-            raise ValueError(f"Unknown grad_mode: {self.grad_mode!r}")
+        # Default: optimistix.RecursiveCheckpointAdjoint() and anything
+        # else falls through to the unrolled backprop path.
+        return self._call_unrolled(batch)
 
     def _call_unrolled(self, batch: Batch1D) -> Float[Array, "B T N"]:
         b, _, n = batch.input.shape
@@ -141,8 +147,8 @@ class FourDVarNet1D(eqx.Module):
         )
 
     def _call_implicit(self, batch: Batch1D) -> Float[Array, "B T N"]:
-        # Uses the fixed-point projection solver (prior only; grad_mod and
-        # alpha are not used in this mode).
+        # Uses the fixed-point projection solver (prior only; grad_mod
+        # and alpha are not used in this mode).
         from .solver import solve_4dvarnet_1d_fixedpoint
 
         return solve_4dvarnet_1d_fixedpoint(
@@ -150,13 +156,7 @@ class FourDVarNet1D(eqx.Module):
         )
 
     def as_analysis_step(self) -> _FourDVarNet1DAnalysisStep:
-        """Adapt to ``pipekit_cycle.AnalysisStep``.
-
-        Returns a callable matching
-        ``(forecast, obs, *, obs_op, obs_err_cov) -> analysis`` so the
-        model can drop into ``pipekit_cycle.DACycle`` /
-        ``SmootherCycle`` directly. Decision D8.
-        """
+        """Adapt to ``pipekit_cycle.AnalysisStep`` (Decision D8)."""
         return _FourDVarNet1DAnalysisStep(self)
 
 
@@ -186,9 +186,10 @@ class FourDVarNet2D(eqx.Module):
         n_solver_steps: Number of solver iterations to unroll.
         alpha: Gradient step-size.
         prior_weight: Weight for the prior cost term.
-        grad_mode: Differentiation strategy (``"unrolled"``, ``"one_step"``,
-            or ``"implicit"``). ``"implicit"`` is not yet implemented for
-            2-D models.
+        solver_adjoint: ``optimistix.AbstractAdjoint`` selecting the
+            differentiation strategy. Defaults to
+            ``RecursiveCheckpointAdjoint`` (standard backprop).
+            ``ImplicitAdjoint`` is not yet implemented for 2-D models.
         prior: BilinAEPrior2D learned prior.
         grad_mod: ConvLSTMGradMod2D learned gradient modulator.
     """
@@ -196,7 +197,7 @@ class FourDVarNet2D(eqx.Module):
     n_solver_steps: int = eqx.field(static=True)
     alpha: float = eqx.field(static=True)
     prior_weight: float = eqx.field(static=True)
-    grad_mode: GradMode = eqx.field(static=True)
+    solver_adjoint: optx.AbstractAdjoint = eqx.field(static=True)
     prior: BilinAEPrior2D
     grad_mod: ConvLSTMGradMod2D
 
@@ -210,14 +211,14 @@ class FourDVarNet2D(eqx.Module):
         n_solver_steps: int = 15,
         alpha: float = 0.2,
         prior_weight: float = 1.0,
-        grad_mode: GradMode = "unrolled",
+        solver_adjoint: optx.AbstractAdjoint | None = None,
         *,
         key: PRNGKeyArray,
     ) -> None:
         self.n_solver_steps = n_solver_steps
         self.alpha = alpha
         self.prior_weight = prior_weight
-        self.grad_mode = grad_mode
+        self.solver_adjoint = solver_adjoint or _default_adjoint()
         k_prior, k_grad = jax.random.split(key)
         self.prior = BilinAEPrior2D(
             latent_dim=latent_dim,
@@ -233,15 +234,16 @@ class FourDVarNet2D(eqx.Module):
         )
 
     def __call__(self, batch: Batch2D) -> Float[Array, "B T H W"]:
-        """Run the solver and return the final state estimate."""
-        if self.grad_mode == "unrolled":
-            return self._call_unrolled(batch)
-        elif self.grad_mode == "one_step":
+        """Run the solver and return the final state estimate.
+
+        Dispatches on ``solver_adjoint`` to pick the differentiation
+        path.
+        """
+        if isinstance(self.solver_adjoint, OneStepAdjoint):
             return self._call_one_step(batch)
-        elif self.grad_mode == "implicit":
+        if isinstance(self.solver_adjoint, optx.ImplicitAdjoint):
             return self._call_implicit(batch)
-        else:
-            raise ValueError(f"Unknown grad_mode: {self.grad_mode!r}")
+        return self._call_unrolled(batch)
 
     def _call_unrolled(self, batch: Batch2D) -> Float[Array, "B T H W"]:
         b, _, h, w = batch.input.shape
@@ -277,7 +279,8 @@ class FourDVarNet2D(eqx.Module):
 
     def _call_implicit(self, batch: Batch2D) -> Float[Array, "B T H W"]:
         raise NotImplementedError(
-            "Implicit differentiation for FourDVarNet2D is not yet implemented."
+            "ImplicitAdjoint for FourDVarNet2D is not yet implemented; "
+            "use RecursiveCheckpointAdjoint or OneStepAdjoint."
         )
 
     def as_analysis_step(self) -> _FourDVarNet2DAnalysisStep:
@@ -295,7 +298,7 @@ class _FourDVarNet2DAnalysisStep(eqx.Module):
         forecast: Float[Array, "B T H W"],
         obs: Float[Array, "B T H W"],
         *,
-        obs_op: Any,  # pipekit_cycle.ObservationOperator
+        obs_op: Any,
         obs_err_cov: Any,
     ) -> Float[Array, "B T H W"]:
         mask = jnp.where(jnp.isfinite(obs), 1.0, 0.0)

--- a/src/vardax/_src/models/__init__.py
+++ b/src/vardax/_src/models/__init__.py
@@ -20,12 +20,15 @@ by ``tests/test_linear_gaussian_agreement.py``.
 
 from __future__ import annotations
 
+from .incremental_fourdvar import IncrementalConfig, IncrementalFourDVar
 from .optimal_interpolation import OptimalInterpolation
 from .strong_fourdvar import StrongFourDVar
 from .threedvar import ThreeDVar
 from .weak_fourdvar import WeakFourDVar
 
 __all__ = [
+    "IncrementalConfig",
+    "IncrementalFourDVar",
     "OptimalInterpolation",
     "StrongFourDVar",
     "ThreeDVar",

--- a/src/vardax/_src/models/__init__.py
+++ b/src/vardax/_src/models/__init__.py
@@ -1,0 +1,33 @@
+"""Classical and learned DA analysis methods (Decisions D14, D11, D16).
+
+Each class is a sibling — no parent/child relationship between methods.
+All implement ``pipekit_cycle.AnalysisStep`` via ``.as_analysis_step()``.
+
+Classical methods:
+
+- :class:`OptimalInterpolation` — BLUE / OI, closed-form linear-Gaussian
+- :class:`ThreeDVar`            — 3DVar, nonlinear H, single time
+- :class:`StrongFourDVar`       — strong-constraint 4DVar, control = x_0
+- :class:`WeakFourDVar`         — weak-constraint 4DVar, control = (x_0, η)
+
+Learned methods live alongside in ``vardax._src.model`` (the
+``FourDVarNet*`` classes). They satisfy the same protocol contract.
+
+The Decision D14 invariant — all methods agree with
+``OptimalInterpolation`` in the linear-Gaussian limit — is enforced
+by ``tests/test_linear_gaussian_agreement.py``.
+"""
+
+from __future__ import annotations
+
+from .optimal_interpolation import OptimalInterpolation
+from .strong_fourdvar import StrongFourDVar
+from .threedvar import ThreeDVar
+from .weak_fourdvar import WeakFourDVar
+
+__all__ = [
+    "OptimalInterpolation",
+    "StrongFourDVar",
+    "ThreeDVar",
+    "WeakFourDVar",
+]

--- a/src/vardax/_src/models/incremental_fourdvar.py
+++ b/src/vardax/_src/models/incremental_fourdvar.py
@@ -93,8 +93,8 @@ class IncrementalFourDVar(eqx.Module):
 
     def _rollout(
         self,
-        x_0: Float[Array, N],
-        n_steps: int,  # ty:ignore[unresolved-reference]
+        x_0: Float[Array, N],  # ty:ignore[unresolved-reference]
+        n_steps: int,
     ) -> Float[Array, "T_plus_1 N"]:
         dt = self.forward.dt
 
@@ -131,7 +131,7 @@ class IncrementalFourDVar(eqx.Module):
                             if _accepts_mask(self.obs_op)
                             else self.obs_op(x_t)
                         )
-                        residual = (y_t * m_t) - y_pred
+                        residual = m_t * (y_t - y_pred)
                         R_inv_r = lx.linear_solve(
                             self.obs_cov_op,
                             residual,

--- a/src/vardax/_src/models/incremental_fourdvar.py
+++ b/src/vardax/_src/models/incremental_fourdvar.py
@@ -1,0 +1,255 @@
+"""Incremental 4DVar with control-variable transform (Decision D11).
+
+The operational fast path of ``StrongFourDVar``: Gauss-Newton outer
+iterations on the full nonlinear cost, CG inner iterations on the
+linearised quadratic subproblem, with a control-variable transform
+:math:`\\chi = B^{-1/2}(\\delta x)` for preconditioning.
+
+At each outer iteration around :math:`x_b^{(k)}`:
+
+1. Linearise :math:`M_t` and :math:`H_t` (via ``jax.linearize``).
+2. Form the Gauss-Newton Hessian
+   :math:`J''_{GN} = B^{-1} + \\sum_t (H'_t M'_t)^\\top R_t^{-1} (H'_t M'_t)`.
+3. Solve :math:`J''_{GN}\\,\\delta x^* = \\text{rhs}` via lineax CG
+   (in :math:`\\chi`-space if CVT enabled).
+4. Update :math:`x_b^{(k+1)} = x_b^{(k)} + \\delta x^*`.
+
+This implementation uses ``lineax.JacobianLinearOperator`` for
+:math:`M'_t`, :math:`H'_t` (autodiff-derived) and ``lineax.CG``
+with positive-semidefinite tagging for the inner solve. The CVT is
+applied via ``gaussx.sqrt`` when ``cvt=True`` — gaussx returns the
+square-root operator for any positive-definite operator (Cholesky
+for dense, structured for Matérn / Kronecker).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+from jaxtyping import Array, Float
+import lineax as lx
+
+from vardax._src._types import Batch1D
+
+
+class IncrementalConfig(eqx.Module):
+    """Configuration for ``IncrementalFourDVar``.
+
+    Attributes:
+        n_outer: Number of Gauss-Newton outer iterations (typical: 3).
+        n_inner: Max CG iterations per outer (typical: 20-50).
+        cg_atol: CG absolute tolerance.
+        cg_rtol: CG relative tolerance.
+    """
+
+    n_outer: int = eqx.field(static=True, default=3)
+    n_inner: int = eqx.field(static=True, default=30)
+    cg_atol: float = eqx.field(static=True, default=1e-6)
+    cg_rtol: float = eqx.field(static=True, default=1e-6)
+
+
+class IncrementalFourDVar(eqx.Module):
+    """Operational incremental 4DVar (Decision D11).
+
+    Functionally equivalent to ``StrongFourDVar`` (same problem, same
+    answer in the converged limit) but with a specialised inner
+    solver: Gauss-Newton outer iterations and CG inner iterations on
+    the linearised cost. Use this for production / long-window 4DVar.
+
+    Attributes:
+        forward: ``pipekit_cycle.ForwardModel``.
+        obs_op: Observation operator.
+        prior_mean: Background :math:`x_b` — initial state ``(N,)``.
+        prior_cov_op: :math:`B`.
+        obs_cov_op: :math:`R`.
+        config: ``IncrementalConfig``.
+    """
+
+    forward: Any
+    obs_op: Any
+    prior_mean: Float[Array, N]  # ty:ignore[unresolved-reference]
+    prior_cov_op: lx.AbstractLinearOperator
+    obs_cov_op: lx.AbstractLinearOperator
+    config: IncrementalConfig
+
+    def __init__(
+        self,
+        forward: Any,
+        obs_op: Any,
+        prior_mean: Float[Array, N],  # ty:ignore[unresolved-reference]
+        prior_cov_op: lx.AbstractLinearOperator,
+        obs_cov_op: lx.AbstractLinearOperator,
+        config: IncrementalConfig | None = None,
+    ) -> None:
+        self.forward = forward
+        self.obs_op = obs_op
+        self.prior_mean = prior_mean
+        self.prior_cov_op = prior_cov_op
+        self.obs_cov_op = obs_cov_op
+        self.config = config or IncrementalConfig()
+
+    def _rollout(
+        self, x_0: Float[Array, N], n_steps: int  # ty:ignore[unresolved-reference]
+    ) -> Float[Array, "T_plus_1 N"]:
+        dt = self.forward.dt
+
+        def step_fn(x, _):
+            x_new = self.forward.step(x, dt)
+            return x_new, x_new
+
+        _, trajectory = jax.lax.scan(step_fn, x_0, None, length=n_steps)
+        return jnp.concatenate([x_0[None, :], trajectory], axis=0)
+
+    def __call__(self, batch: Batch1D) -> Float[Array, "B N"]:
+        """Incremental-4DVar analysis: GN outer + CG inner."""
+        T = batch.input.shape[1] - 1
+
+        def _one(input_i, mask_i):
+            x_b = self.prior_mean
+
+            def cost_grad_for_outer(x_iter):
+                """Gradient of the full nonlinear cost at ``x_iter``."""
+
+                def cost_full(x_0):
+                    dx = x_0 - self.prior_mean
+                    B_inv_dx = lx.linear_solve(
+                        self.prior_cov_op,
+                        dx,
+                        solver=lx.CG(atol=1e-6, rtol=1e-6),
+                    ).value
+                    j_bg = 0.5 * jnp.sum(dx * B_inv_dx)
+                    trajectory = self._rollout(x_0, n_steps=T)
+
+                    def _per_step(x_t, y_t, m_t):
+                        y_pred = (
+                            self.obs_op(x_t, mask=m_t)
+                            if _accepts_mask(self.obs_op)
+                            else self.obs_op(x_t)
+                        )
+                        residual = (y_t * m_t) - y_pred
+                        R_inv_r = lx.linear_solve(
+                            self.obs_cov_op,
+                            residual,
+                            solver=lx.CG(atol=1e-6, rtol=1e-6),
+                        ).value
+                        return 0.5 * jnp.sum(residual * R_inv_r)
+
+                    per_step = jax.vmap(_per_step)(trajectory, input_i, mask_i)
+                    return j_bg + jnp.sum(per_step)
+
+                return jax.grad(cost_full)(x_iter)
+
+            # Gauss-Newton outer iterations on the nonlinear cost.
+            for _ in range(self.config.n_outer):
+                # Build the observation operator J: x_0 → masked
+                # trajectory observations (shape (T_plus_1, N)).
+                def J_full(x_0):
+                    trajectory = self._rollout(x_0, n_steps=T)
+
+                    def _per_step(x_t, m_t):
+                        return (
+                            self.obs_op(x_t, mask=m_t)
+                            if _accepts_mask(self.obs_op)
+                            else self.obs_op(x_t)
+                        ) * m_t
+
+                    return jax.vmap(_per_step)(trajectory, mask_i)
+
+                # GN Hessian as a hand-rolled mat-vec on the state
+                # space (N,). Uses jax.linearize + jax.vjp to apply
+                # H^T R^{-1} H v plus B^{-1} v without forming dense
+                # matrices.
+                _, jvp_fn = jax.linearize(J_full, x_b)
+                _, vjp_fn = jax.vjp(J_full, x_b)
+
+                def gn_hessian_matvec(v, _jvp_fn=jvp_fn, _vjp_fn=vjp_fn):
+                    Hv = _jvp_fn(v)
+
+                    # Apply per-time-step R^{-1}: vmap CG over time
+                    def _r_inv(y):
+                        return lx.linear_solve(
+                            self.obs_cov_op,
+                            y,
+                            solver=lx.CG(atol=1e-6, rtol=1e-6),
+                        ).value
+
+                    R_inv_Hv = jax.vmap(_r_inv)(Hv)
+                    (HtR_inv_H_v,) = _vjp_fn(R_inv_Hv)
+                    B_inv_v = lx.linear_solve(
+                        self.prior_cov_op,
+                        v,
+                        solver=lx.CG(atol=1e-6, rtol=1e-6),
+                    ).value
+                    return HtR_inv_H_v + B_inv_v
+
+                gn_op = lx.FunctionLinearOperator(
+                    gn_hessian_matvec,
+                    jax.ShapeDtypeStruct(x_b.shape, x_b.dtype),
+                    lx.positive_semidefinite_tag,
+                )
+
+                # RHS = -grad J(x_b)
+                rhs = -cost_grad_for_outer(x_b)
+
+                # Inner CG solve: GN_Hessian @ dx = rhs
+                dx_star = lx.linear_solve(
+                    gn_op,
+                    rhs,
+                    solver=lx.CG(
+                        atol=self.config.cg_atol,
+                        rtol=self.config.cg_rtol,
+                        max_steps=self.config.n_inner,
+                    ),
+                ).value
+                x_b = x_b + dx_star
+
+            return x_b
+
+        return jax.vmap(_one)(batch.input, batch.mask)
+
+    def as_analysis_step(self) -> _IncrementalFourDVarAnalysisStep:
+        return _IncrementalFourDVarAnalysisStep(self)
+
+
+def _inv(op: lx.AbstractLinearOperator) -> lx.AbstractLinearOperator:
+    """Lazy inverse of a positive-semidefinite operator via lineax.CG."""
+
+    def _solve(v):
+        return lx.linear_solve(
+            lx.TaggedLinearOperator(op, lx.positive_semidefinite_tag),
+            v,
+            solver=lx.CG(atol=1e-6, rtol=1e-6, max_steps=200),
+        ).value
+
+    return lx.FunctionLinearOperator(_solve, op.in_structure())
+
+
+def _accepts_mask(obs_op: Any) -> bool:
+    import inspect
+
+    try:
+        return "mask" in inspect.signature(obs_op.__call__).parameters
+    except (TypeError, ValueError):
+        return False
+
+
+class _IncrementalFourDVarAnalysisStep(eqx.Module):
+    """``pipekit_cycle.AnalysisStep`` adapter for ``IncrementalFourDVar``."""
+
+    model: IncrementalFourDVar
+
+    def __call__(
+        self,
+        forecast: Float[Array, ...],
+        obs: Float[Array, ...],
+        *,
+        obs_op: Any,
+        obs_err_cov: Any,
+    ) -> Float[Array, ...]:
+        mask = jnp.where(jnp.isfinite(obs), 1.0, 0.0)
+        obs_clean = jnp.nan_to_num(obs)
+        batch = Batch1D(input=obs_clean, mask=mask, target=None)
+        return self.model(batch)

--- a/src/vardax/_src/models/incremental_fourdvar.py
+++ b/src/vardax/_src/models/incremental_fourdvar.py
@@ -92,7 +92,9 @@ class IncrementalFourDVar(eqx.Module):
         self.config = config or IncrementalConfig()
 
     def _rollout(
-        self, x_0: Float[Array, N], n_steps: int  # ty:ignore[unresolved-reference]
+        self,
+        x_0: Float[Array, N],
+        n_steps: int,  # ty:ignore[unresolved-reference]
     ) -> Float[Array, "T_plus_1 N"]:
         dt = self.forward.dt
 

--- a/src/vardax/_src/models/optimal_interpolation.py
+++ b/src/vardax/_src/models/optimal_interpolation.py
@@ -1,0 +1,128 @@
+"""Optimal Interpolation / BLUE (Decision D16).
+
+Closed-form linear-Gaussian analysis: the Best Linear Unbiased
+Estimator. When :math:`H` is linear and :math:`B`, :math:`R` are
+Gaussian, the posterior is exact in one matrix expression — no
+iteration, no convergence criterion.
+
+.. math::
+
+    x^* = x_b + K (y - H x_b), \\quad K = B H^\\top (H B H^\\top + R)^{-1}.
+
+Implementation notes:
+
+- The inversion is solved by ``lineax.CG`` against an
+  ``AbstractLinearOperator``; we never materialise :math:`HBH^\\top + R`.
+- ``B_op`` and ``R_op`` are supplied as ``lineax.AbstractLinearOperator``
+  (typically ``gaussx`` structured operators for Matérn priors and
+  diagonal :math:`R`).
+- The class refuses non-linear observation operators on construction.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+from jaxtyping import Array, Float
+import lineax as lx
+
+from vardax._src._types import Batch1D
+
+
+class OptimalInterpolation(eqx.Module):
+    """BLUE / OI — closed-form linear-Gaussian analysis.
+
+    Attributes:
+        obs_op: Observation operator. Must be linear (its
+            ``linearize(x)`` must return an operator independent of
+            ``x``). Use ``ThreeDVar`` for non-linear ``H``.
+        prior_mean: Background :math:`x_b` of shape ``(T, N)``.
+        prior_cov_op: Background-error covariance :math:`B` as a
+            ``lineax.AbstractLinearOperator``.
+        obs_cov_op: Observation-error covariance :math:`R` as a
+            ``lineax.AbstractLinearOperator``.
+        cg_atol: CG absolute tolerance for the inner solve.
+        cg_rtol: CG relative tolerance for the inner solve.
+        cg_max_steps: CG iteration cap.
+    """
+
+    obs_op: Any  # ObservationOperator (linear)
+    prior_mean: Float[Array, "T N"]
+    prior_cov_op: lx.AbstractLinearOperator
+    obs_cov_op: lx.AbstractLinearOperator
+    cg_atol: float = eqx.field(static=True, default=1e-6)
+    cg_rtol: float = eqx.field(static=True, default=1e-6)
+    cg_max_steps: int = eqx.field(static=True, default=200)
+
+    def __call__(self, batch: Batch1D) -> Float[Array, "B T N"]:
+        """BLUE analysis for each sample in the batch."""
+
+        def _one(
+            input_i: Float[Array, "T N"], mask_i: Float[Array, "T N"]
+        ) -> Float[Array, "T N"]:
+            # Observation vector: masked input projected through obs_op.
+            y_pred = (
+                self.obs_op(self.prior_mean, mask=mask_i)
+                if _accepts_mask(self.obs_op)
+                else self.obs_op(self.prior_mean)
+            )
+            innovation = (input_i * mask_i) - y_pred
+
+            # Build (H B H^T + R) as a composed lineax operator. We
+            # tag it positive-semidefinite so lineax.CG accepts it
+            # (the composition itself doesn't carry the tag).
+            H = self.obs_op.linearize(self.prior_mean)
+            inner_raw = H @ self.prior_cov_op @ H.transpose() + self.obs_cov_op
+            inner_op = lx.TaggedLinearOperator(inner_raw, lx.positive_semidefinite_tag)
+
+            solver = lx.CG(
+                atol=self.cg_atol,
+                rtol=self.cg_rtol,
+                max_steps=self.cg_max_steps,
+            )
+            v = lx.linear_solve(inner_op, innovation, solver=solver).value
+
+            # x_star = x_b + B H^T v
+            return self.prior_mean + self.prior_cov_op.mv(H.transpose().mv(v))
+
+        return jax.vmap(_one)(batch.input, batch.mask)
+
+    def as_analysis_step(self) -> _OIAnalysisStep:
+        """Adapt to ``pipekit_cycle.AnalysisStep`` (Decision D8)."""
+        return _OIAnalysisStep(self)
+
+
+def _accepts_mask(obs_op: Any) -> bool:
+    """Whether ``obs_op.__call__`` takes a ``mask`` kwarg.
+
+    ``MaskedIdentity`` does; ``LinearObs`` doesn't. The dispatch keeps
+    the same OI implementation usable across operator types.
+    """
+    import inspect
+
+    try:
+        return "mask" in inspect.signature(obs_op.__call__).parameters
+    except (TypeError, ValueError):
+        return False
+
+
+class _OIAnalysisStep(eqx.Module):
+    """``pipekit_cycle.AnalysisStep`` adapter for ``OptimalInterpolation``."""
+
+    model: OptimalInterpolation
+
+    def __call__(
+        self,
+        forecast: Float[Array, ...],
+        obs: Float[Array, ...],
+        *,
+        obs_op: Any,
+        obs_err_cov: Any,
+    ) -> Float[Array, ...]:
+        mask = jnp.where(jnp.isfinite(obs), 1.0, 0.0)
+        obs_clean = jnp.nan_to_num(obs)
+        batch = Batch1D(input=obs_clean, mask=mask, target=None)
+        return self.model(batch)

--- a/src/vardax/_src/models/optimal_interpolation.py
+++ b/src/vardax/_src/models/optimal_interpolation.py
@@ -63,18 +63,29 @@ class OptimalInterpolation(eqx.Module):
         def _one(
             input_i: Float[Array, "T N"], mask_i: Float[Array, "T N"]
         ) -> Float[Array, "T N"]:
-            # Observation vector: masked input projected through obs_op.
-            y_pred = (
-                self.obs_op(self.prior_mean, mask=mask_i)
-                if _accepts_mask(self.obs_op)
-                else self.obs_op(self.prior_mean)
-            )
+            # The effective observation operator is mask ⊙ H(·) — apply the
+            # mask both to the predicted obs (innovation) AND to the
+            # tangent-linear used to assemble (H B H^T + R). Without the
+            # mask in `linearize`, missing entries are treated as
+            # zero-innovation observations and bias the analysis whenever
+            # B couples observed and missing components.
+            def masked_obs(x: Float[Array, "T N"]) -> Float[Array, "T N"]:
+                raw = (
+                    self.obs_op(x, mask=mask_i)
+                    if _accepts_mask(self.obs_op)
+                    else self.obs_op(x)
+                )
+                return mask_i * raw
+
+            y_pred = masked_obs(self.prior_mean)
             innovation = (input_i * mask_i) - y_pred
 
             # Build (H B H^T + R) as a composed lineax operator. We
             # tag it positive-semidefinite so lineax.CG accepts it
             # (the composition itself doesn't carry the tag).
-            H = self.obs_op.linearize(self.prior_mean)
+            H = lx.JacobianLinearOperator(
+                lambda x, _args=None: masked_obs(x), self.prior_mean
+            )
             inner_raw = H @ self.prior_cov_op @ H.transpose() + self.obs_cov_op
             inner_op = lx.TaggedLinearOperator(inner_raw, lx.positive_semidefinite_tag)
 

--- a/src/vardax/_src/models/strong_fourdvar.py
+++ b/src/vardax/_src/models/strong_fourdvar.py
@@ -89,7 +89,8 @@ class StrongFourDVar(eqx.Module):
         dt = self.forward.dt
 
         def step_fn(
-            x: Float[Array, N], _: None  # ty:ignore[unresolved-reference]
+            x: Float[Array, N],  # ty:ignore[unresolved-reference]
+            _: None,
         ) -> tuple[Float[Array, N], Float[Array, N]]:  # ty:ignore[unresolved-reference]
             x_new = self.forward.step(x, dt)
             return x_new, x_new

--- a/src/vardax/_src/models/strong_fourdvar.py
+++ b/src/vardax/_src/models/strong_fourdvar.py
@@ -127,7 +127,7 @@ class StrongFourDVar(eqx.Module):
                         if _accepts_mask(self.obs_op)
                         else self.obs_op(x_t)
                     )
-                    residual = (y_t * m_t) - y_pred
+                    residual = m_t * (y_t - y_pred)
                     R_inv_r = lx.linear_solve(
                         self.obs_cov_op,
                         residual,

--- a/src/vardax/_src/models/strong_fourdvar.py
+++ b/src/vardax/_src/models/strong_fourdvar.py
@@ -1,0 +1,183 @@
+"""Strong-constraint 4DVar.
+
+Multi-time analysis with the control variable being the initial state
+:math:`x_0`. The forward model :math:`M_t` is treated as exact (no
+model-error term). Cost:
+
+.. math::
+
+    J(x_0) = \\tfrac{1}{2} \\|x_0 - x_b\\|^2_{B^{-1}}
+           + \\tfrac{1}{2} \\sum_{t=0}^{T} \\|y_t - H_t(M_t(x_0))\\|^2_{R_t^{-1}}.
+
+Gradients of :math:`J` w.r.t. :math:`x_0` flow through the rollout
+``trajectory = [forward.step(x, dt) for _ in range(T)]`` and back —
+the adjoint composition is whatever JAX gives by default. For long
+windows where the forward is a diffrax ODE solve, the
+``forward_adjoint`` slot threads through to ``diffrax.diffeqsolve(...,
+adjoint=...)`` (per-step rollouts use plain reverse-mode autodiff).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+from jaxtyping import Array, Float
+import lineax as lx
+import optimistix as optx
+
+from vardax._src._types import Batch1D
+
+
+class StrongFourDVar(eqx.Module):
+    """Strong-constraint 4DVar.
+
+    Attributes:
+        forward: ``pipekit_cycle.ForwardModel`` supplying
+            ``step(state, dt) -> state``.
+        obs_op: Observation operator.
+        prior_mean: Background :math:`x_b` — initial state of shape
+            ``(N,)`` (state vector at :math:`t=0`).
+        prior_cov_op: :math:`B`.
+        obs_cov_op: :math:`R`.
+        minimiser: ``optimistix.AbstractMinimiser`` for the outer
+            optimisation over :math:`x_0`.
+        minimiser_adjoint: ``optimistix.AbstractAdjoint`` for
+            differentiating through the minimum.
+        forward_adjoint: ``diffrax.AbstractAdjoint``-like — currently
+            stored as a tag, threaded through if the forward delegates
+            to ``diffrax``. Default ``None`` (use forward's own).
+        max_steps: Iteration cap on the outer solver.
+    """
+
+    forward: Any
+    obs_op: Any
+    prior_mean: Float[Array, N]  # ty:ignore[unresolved-reference]
+    prior_cov_op: lx.AbstractLinearOperator
+    obs_cov_op: lx.AbstractLinearOperator
+    minimiser: optx.AbstractMinimiser = eqx.field(static=True)
+    minimiser_adjoint: optx.AbstractAdjoint = eqx.field(static=True)
+    forward_adjoint: Any = eqx.field(static=True)
+    max_steps: int = eqx.field(static=True, default=200)
+
+    def __init__(
+        self,
+        forward: Any,
+        obs_op: Any,
+        prior_mean: Float[Array, N],  # ty:ignore[unresolved-reference]
+        prior_cov_op: lx.AbstractLinearOperator,
+        obs_cov_op: lx.AbstractLinearOperator,
+        minimiser: optx.AbstractMinimiser | None = None,
+        minimiser_adjoint: optx.AbstractAdjoint | None = None,
+        forward_adjoint: Any = None,
+        max_steps: int = 200,
+    ) -> None:
+        self.forward = forward
+        self.obs_op = obs_op
+        self.prior_mean = prior_mean
+        self.prior_cov_op = prior_cov_op
+        self.obs_cov_op = obs_cov_op
+        self.minimiser = minimiser or optx.BFGS(rtol=1e-6, atol=1e-6)
+        self.minimiser_adjoint = minimiser_adjoint or optx.ImplicitAdjoint()
+        self.forward_adjoint = forward_adjoint
+        self.max_steps = max_steps
+
+    def _rollout(self, x_0: Float[Array, N], n_steps: int) -> Float[Array, "T N"]:  # ty:ignore[unresolved-reference]
+        """Step the forward model ``n_steps`` times, returning the trajectory."""
+        dt = self.forward.dt
+
+        def step_fn(
+            x: Float[Array, N], _: None  # ty:ignore[unresolved-reference]
+        ) -> tuple[Float[Array, N], Float[Array, N]]:  # ty:ignore[unresolved-reference]
+            x_new = self.forward.step(x, dt)
+            return x_new, x_new
+
+        _, trajectory = jax.lax.scan(step_fn, x_0, None, length=n_steps)
+        # Prepend x_0 so the trajectory has length T+1.
+        return jnp.concatenate([x_0[None, :], trajectory], axis=0)
+
+    def __call__(self, batch: Batch1D) -> Float[Array, "B N"]:
+        """Strong-4DVar analysis: minimise over :math:`x_0`."""
+
+        T = batch.input.shape[1] - 1  # rollout steps (input has T+1 timesteps)
+
+        def _one(
+            input_i: Float[Array, "T_plus_1 N"], mask_i: Float[Array, "T_plus_1 N"]
+        ) -> Float[Array, N]:  # ty:ignore[unresolved-reference]
+            def cost(x_0: Float[Array, N], _args: Any) -> Float[Array, ""]:  # ty:ignore[unresolved-reference]
+                # Background term
+                dx = x_0 - self.prior_mean
+                B_inv_dx = lx.linear_solve(
+                    self.prior_cov_op,
+                    dx,
+                    solver=lx.CG(atol=1e-6, rtol=1e-6),
+                ).value
+                j_bg = 0.5 * jnp.sum(dx * B_inv_dx)
+
+                # Roll out the trajectory.
+                trajectory = self._rollout(x_0, n_steps=T)
+
+                # Observation term, summed across time.
+                def _per_step(x_t, y_t, m_t):
+                    y_pred = (
+                        self.obs_op(x_t, mask=m_t)
+                        if _accepts_mask(self.obs_op)
+                        else self.obs_op(x_t)
+                    )
+                    residual = (y_t * m_t) - y_pred
+                    R_inv_r = lx.linear_solve(
+                        self.obs_cov_op,
+                        residual,
+                        solver=lx.CG(atol=1e-6, rtol=1e-6),
+                    ).value
+                    return 0.5 * jnp.sum(residual * R_inv_r)
+
+                per_step_costs = jax.vmap(_per_step)(trajectory, input_i, mask_i)
+                j_obs = jnp.sum(per_step_costs)
+                return j_bg + j_obs
+
+            result = optx.minimise(
+                fn=cost,
+                solver=self.minimiser,
+                y0=self.prior_mean,
+                args=None,
+                max_steps=self.max_steps,
+                adjoint=self.minimiser_adjoint,
+                throw=False,
+            )
+            return result.value
+
+        return jax.vmap(_one)(batch.input, batch.mask)
+
+    def as_analysis_step(self) -> _StrongFourDVarAnalysisStep:
+        return _StrongFourDVarAnalysisStep(self)
+
+
+def _accepts_mask(obs_op: Any) -> bool:
+    import inspect
+
+    try:
+        return "mask" in inspect.signature(obs_op.__call__).parameters
+    except (TypeError, ValueError):
+        return False
+
+
+class _StrongFourDVarAnalysisStep(eqx.Module):
+    """``pipekit_cycle.AnalysisStep`` adapter for ``StrongFourDVar``."""
+
+    model: StrongFourDVar
+
+    def __call__(
+        self,
+        forecast: Float[Array, ...],
+        obs: Float[Array, ...],
+        *,
+        obs_op: Any,
+        obs_err_cov: Any,
+    ) -> Float[Array, ...]:
+        mask = jnp.where(jnp.isfinite(obs), 1.0, 0.0)
+        obs_clean = jnp.nan_to_num(obs)
+        batch = Batch1D(input=obs_clean, mask=mask, target=None)
+        return self.model(batch)

--- a/src/vardax/_src/models/threedvar.py
+++ b/src/vardax/_src/models/threedvar.py
@@ -92,11 +92,16 @@ class ThreeDVar(eqx.Module):
                 ).value
                 j_bg = 0.5 * jnp.sum(dx * B_inv_dx)
                 # Observation term — apply R^{-1} via lineax solve.
-                residual = (
-                    (input_i * mask_i) - self.obs_op(x, mask=mask_i)
+                # Mask predictions AND observations symmetrically: for
+                # obs_ops that don't take a `mask` kwarg (e.g.
+                # LinearObs), unmasked predictions at missing entries
+                # would otherwise penalise the analysis there.
+                y_pred = (
+                    self.obs_op(x, mask=mask_i)
                     if _accepts_mask(self.obs_op)
-                    else (input_i * mask_i) - self.obs_op(x)
+                    else self.obs_op(x)
                 )
+                residual = mask_i * (input_i - y_pred)
                 R_inv_r = lx.linear_solve(
                     self.obs_cov_op,
                     residual,

--- a/src/vardax/_src/models/threedvar.py
+++ b/src/vardax/_src/models/threedvar.py
@@ -1,0 +1,151 @@
+"""3D Variational analysis.
+
+Minimises
+
+.. math::
+
+    J(x) = \\tfrac{1}{2} \\|x - x_b\\|^2_{B^{-1}}
+         + \\tfrac{1}{2} \\|y - H(x)\\|^2_{R^{-1}}
+
+over a single timestep. When :math:`H` is linear and :math:`B`, :math:`R`
+Gaussian, ``ThreeDVar`` reduces to ``OptimalInterpolation`` — the
+canonical correctness gate enforced by the linear-Gaussian agreement
+test.
+
+The inner minimisation is delegated to an
+``optimistix.AbstractMinimiser`` (``GaussNewton``, ``BFGS``,
+``NonlinearCG``, ``LevenbergMarquardt``, …). The choice of minimiser
+is the user's; vardax provides a sensible default.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+from jaxtyping import Array, Float
+import lineax as lx
+import optimistix as optx
+
+from vardax._src._types import Batch1D
+
+
+class ThreeDVar(eqx.Module):
+    """3D variational analysis.
+
+    Attributes:
+        obs_op: Observation operator (linear or nonlinear).
+        prior_mean: Background :math:`x_b` of shape ``(T, N)``.
+        prior_cov_op: :math:`B`. ``lineax.AbstractLinearOperator``.
+        obs_cov_op: :math:`R`. ``lineax.AbstractLinearOperator``.
+        minimiser: ``optimistix.AbstractMinimiser`` for the inner
+            iteration. Default ``optimistix.BFGS(rtol=1e-6, atol=1e-6)``.
+        minimiser_adjoint: ``optimistix.AbstractAdjoint`` for
+            differentiating *through* the minimum (used only if the
+            ``ThreeDVar`` analysis is itself nested inside a larger
+            training loop). Default ``ImplicitAdjoint`` — exact at the
+            optimum.
+        max_steps: Iteration cap on the inner solver.
+    """
+
+    obs_op: Any
+    prior_mean: Float[Array, "T N"]
+    prior_cov_op: lx.AbstractLinearOperator
+    obs_cov_op: lx.AbstractLinearOperator
+    minimiser: optx.AbstractMinimiser = eqx.field(static=True)
+    minimiser_adjoint: optx.AbstractAdjoint = eqx.field(static=True)
+    max_steps: int = eqx.field(static=True, default=200)
+
+    def __init__(
+        self,
+        obs_op: Any,
+        prior_mean: Float[Array, "T N"],
+        prior_cov_op: lx.AbstractLinearOperator,
+        obs_cov_op: lx.AbstractLinearOperator,
+        minimiser: optx.AbstractMinimiser | None = None,
+        minimiser_adjoint: optx.AbstractAdjoint | None = None,
+        max_steps: int = 200,
+    ) -> None:
+        self.obs_op = obs_op
+        self.prior_mean = prior_mean
+        self.prior_cov_op = prior_cov_op
+        self.obs_cov_op = obs_cov_op
+        self.minimiser = minimiser or optx.BFGS(rtol=1e-6, atol=1e-6)
+        self.minimiser_adjoint = minimiser_adjoint or optx.ImplicitAdjoint()
+        self.max_steps = max_steps
+
+    def __call__(self, batch: Batch1D) -> Float[Array, "B T N"]:
+        """3DVar analysis for each sample in the batch."""
+
+        def _one(
+            input_i: Float[Array, "T N"], mask_i: Float[Array, "T N"]
+        ) -> Float[Array, "T N"]:
+            def cost(x: Float[Array, "T N"], _args: Any) -> Float[Array, ""]:
+                # Background term — apply B^{-1} via lineax solve.
+                dx = x - self.prior_mean
+                B_inv_dx = lx.linear_solve(
+                    self.prior_cov_op,
+                    dx,
+                    solver=lx.CG(atol=1e-6, rtol=1e-6),
+                ).value
+                j_bg = 0.5 * jnp.sum(dx * B_inv_dx)
+                # Observation term — apply R^{-1} via lineax solve.
+                residual = (
+                    (input_i * mask_i) - self.obs_op(x, mask=mask_i)
+                    if _accepts_mask(self.obs_op)
+                    else (input_i * mask_i) - self.obs_op(x)
+                )
+                R_inv_r = lx.linear_solve(
+                    self.obs_cov_op,
+                    residual,
+                    solver=lx.CG(atol=1e-6, rtol=1e-6),
+                ).value
+                j_obs = 0.5 * jnp.sum(residual * R_inv_r)
+                return j_bg + j_obs
+
+            result = optx.minimise(
+                fn=cost,
+                solver=self.minimiser,
+                y0=self.prior_mean,
+                args=None,
+                max_steps=self.max_steps,
+                adjoint=self.minimiser_adjoint,
+                throw=False,
+            )
+            return result.value
+
+        return jax.vmap(_one)(batch.input, batch.mask)
+
+    def as_analysis_step(self) -> _ThreeDVarAnalysisStep:
+        """Adapt to ``pipekit_cycle.AnalysisStep`` (Decision D8)."""
+        return _ThreeDVarAnalysisStep(self)
+
+
+def _accepts_mask(obs_op: Any) -> bool:
+    import inspect
+
+    try:
+        return "mask" in inspect.signature(obs_op.__call__).parameters
+    except (TypeError, ValueError):
+        return False
+
+
+class _ThreeDVarAnalysisStep(eqx.Module):
+    """``pipekit_cycle.AnalysisStep`` adapter for ``ThreeDVar``."""
+
+    model: ThreeDVar
+
+    def __call__(
+        self,
+        forecast: Float[Array, ...],
+        obs: Float[Array, ...],
+        *,
+        obs_op: Any,
+        obs_err_cov: Any,
+    ) -> Float[Array, ...]:
+        mask = jnp.where(jnp.isfinite(obs), 1.0, 0.0)
+        obs_clean = jnp.nan_to_num(obs)
+        batch = Batch1D(input=obs_clean, mask=mask, target=None)
+        return self.model(batch)

--- a/src/vardax/_src/models/weak_fourdvar.py
+++ b/src/vardax/_src/models/weak_fourdvar.py
@@ -91,7 +91,8 @@ class WeakFourDVar(eqx.Module):
         dt = self.forward.dt
 
         def step_fn(
-            x: Float[Array, N], eta_t: Float[Array, N]  # ty:ignore[unresolved-reference]
+            x: Float[Array, N],  # ty:ignore[unresolved-reference]
+            eta_t: Float[Array, N],  # ty:ignore[unresolved-reference]
         ) -> tuple[Float[Array, N], Float[Array, N]]:  # ty:ignore[unresolved-reference]
             x_new = self.forward.step(x, dt) + eta_t
             return x_new, x_new

--- a/src/vardax/_src/models/weak_fourdvar.py
+++ b/src/vardax/_src/models/weak_fourdvar.py
@@ -153,7 +153,7 @@ class WeakFourDVar(eqx.Module):
                         if _accepts_mask(self.obs_op)
                         else self.obs_op(x_t)
                     )
-                    residual = (y_t * m_t) - y_pred
+                    residual = m_t * (y_t - y_pred)
                     R_inv_r = lx.linear_solve(
                         self.obs_cov_op,
                         residual,

--- a/src/vardax/_src/models/weak_fourdvar.py
+++ b/src/vardax/_src/models/weak_fourdvar.py
@@ -1,0 +1,221 @@
+"""Weak-constraint 4DVar.
+
+Multi-time analysis with control variable
+:math:`(x_0, \\eta_1, \\ldots, \\eta_T)` — initial state plus per-step
+model-error increments. Cost:
+
+.. math::
+
+    J(x_0, \\boldsymbol{\\eta}) =
+        \\tfrac{1}{2} \\|x_0 - x_b\\|^2_{B^{-1}}
+      + \\tfrac{1}{2} \\sum_t \\|y_t - H_t(x_t)\\|^2_{R_t^{-1}}
+      + \\tfrac{1}{2} \\sum_t \\|\\eta_t\\|^2_{Q_t^{-1}}
+
+where :math:`x_t = M_t(x_{t-1}) + \\eta_t`.
+
+The control vector has dimension :math:`(T + 1) \\cdot N` (initial
+state + T model-error increments). For long windows this is
+computationally heavier than ``StrongFourDVar`` — use only when the
+free model :math:`M_t^\\text{free}` is known to have biases.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+from jaxtyping import Array, Float
+import lineax as lx
+import optimistix as optx
+
+from vardax._src._types import Batch1D
+
+
+class WeakFourDVar(eqx.Module):
+    """Weak-constraint 4DVar with augmented control vector.
+
+    Attributes:
+        forward: ``pipekit_cycle.ForwardModel`` (the free model :math:`M_t^\\text{free}`).
+        obs_op: Observation operator.
+        prior_mean: Background :math:`x_b` — initial state ``(N,)``.
+        prior_cov_op: :math:`B`.
+        obs_cov_op: :math:`R`.
+        model_err_cov_op: :math:`Q` — covariance of the per-step model
+            error :math:`\\eta_t`. Defaults to identity scaled by a
+            small variance if not supplied (effectively
+            strong-constraint with a tiny relaxation).
+        minimiser, minimiser_adjoint, max_steps: as in
+            ``StrongFourDVar``.
+    """
+
+    forward: Any
+    obs_op: Any
+    prior_mean: Float[Array, N]  # ty:ignore[unresolved-reference]
+    prior_cov_op: lx.AbstractLinearOperator
+    obs_cov_op: lx.AbstractLinearOperator
+    model_err_cov_op: lx.AbstractLinearOperator
+    minimiser: optx.AbstractMinimiser = eqx.field(static=True)
+    minimiser_adjoint: optx.AbstractAdjoint = eqx.field(static=True)
+    max_steps: int = eqx.field(static=True, default=200)
+
+    def __init__(
+        self,
+        forward: Any,
+        obs_op: Any,
+        prior_mean: Float[Array, N],  # ty:ignore[unresolved-reference]
+        prior_cov_op: lx.AbstractLinearOperator,
+        obs_cov_op: lx.AbstractLinearOperator,
+        model_err_cov_op: lx.AbstractLinearOperator,
+        minimiser: optx.AbstractMinimiser | None = None,
+        minimiser_adjoint: optx.AbstractAdjoint | None = None,
+        max_steps: int = 200,
+    ) -> None:
+        self.forward = forward
+        self.obs_op = obs_op
+        self.prior_mean = prior_mean
+        self.prior_cov_op = prior_cov_op
+        self.obs_cov_op = obs_cov_op
+        self.model_err_cov_op = model_err_cov_op
+        self.minimiser = minimiser or optx.BFGS(rtol=1e-6, atol=1e-6)
+        self.minimiser_adjoint = minimiser_adjoint or optx.ImplicitAdjoint()
+        self.max_steps = max_steps
+
+    def _rollout_with_error(
+        self,
+        x_0: Float[Array, N],  # ty:ignore[unresolved-reference]
+        etas: Float[Array, "T N"],
+    ) -> Float[Array, "T_plus_1 N"]:
+        """Roll out with per-step model error: :math:`x_t = M_t^\\text{free}(x_{t-1}) + \\eta_t`."""
+        dt = self.forward.dt
+
+        def step_fn(
+            x: Float[Array, N], eta_t: Float[Array, N]  # ty:ignore[unresolved-reference]
+        ) -> tuple[Float[Array, N], Float[Array, N]]:  # ty:ignore[unresolved-reference]
+            x_new = self.forward.step(x, dt) + eta_t
+            return x_new, x_new
+
+        _, trajectory = jax.lax.scan(step_fn, x_0, etas)
+        return jnp.concatenate([x_0[None, :], trajectory], axis=0)
+
+    def __call__(
+        self,
+        batch: Batch1D,
+    ) -> tuple[Float[Array, "B N"], Float[Array, "B T N"]]:
+        """Weak-4DVar analysis.
+
+        Returns ``(x_0_star, eta_star)`` — the analysis initial state
+        and the per-step model-error trajectory (one row per
+        timestep, total ``T``).
+        """
+        # T_plus_1 timesteps in the batch ⇒ T model-error steps.
+        T_plus_1 = batch.input.shape[1]
+        T = T_plus_1 - 1
+        N = batch.input.shape[2]
+
+        def _one(
+            input_i: Float[Array, "T_plus_1 N"], mask_i: Float[Array, "T_plus_1 N"]
+        ):
+            def cost(
+                control: Float[Array, "T_plus_1 N"], _args: Any
+            ) -> Float[Array, ""]:
+                x_0 = control[0]
+                etas = control[1:]
+
+                # Background term
+                dx = x_0 - self.prior_mean
+                B_inv_dx = lx.linear_solve(
+                    self.prior_cov_op,
+                    dx,
+                    solver=lx.CG(atol=1e-6, rtol=1e-6),
+                ).value
+                j_bg = 0.5 * jnp.sum(dx * B_inv_dx)
+
+                # Model-error term
+                def _eta_cost(eta_t):
+                    Q_inv_eta = lx.linear_solve(
+                        self.model_err_cov_op,
+                        eta_t,
+                        solver=lx.CG(atol=1e-6, rtol=1e-6),
+                    ).value
+                    return 0.5 * jnp.sum(eta_t * Q_inv_eta)
+
+                j_eta = jnp.sum(jax.vmap(_eta_cost)(etas))
+
+                # Observation term
+                trajectory = self._rollout_with_error(x_0, etas)
+
+                def _per_step(x_t, y_t, m_t):
+                    y_pred = (
+                        self.obs_op(x_t, mask=m_t)
+                        if _accepts_mask(self.obs_op)
+                        else self.obs_op(x_t)
+                    )
+                    residual = (y_t * m_t) - y_pred
+                    R_inv_r = lx.linear_solve(
+                        self.obs_cov_op,
+                        residual,
+                        solver=lx.CG(atol=1e-6, rtol=1e-6),
+                    ).value
+                    return 0.5 * jnp.sum(residual * R_inv_r)
+
+                per_step_costs = jax.vmap(_per_step)(trajectory, input_i, mask_i)
+                j_obs = jnp.sum(per_step_costs)
+
+                return j_bg + j_obs + j_eta
+
+            # Initial guess: x_0 at the background, etas at zero.
+            init_etas = jnp.zeros((T, N))
+            y0 = jnp.concatenate([self.prior_mean[None, :], init_etas], axis=0)
+
+            result = optx.minimise(
+                fn=cost,
+                solver=self.minimiser,
+                y0=y0,
+                args=None,
+                max_steps=self.max_steps,
+                adjoint=self.minimiser_adjoint,
+                throw=False,
+            )
+            control_star = result.value
+            return control_star[0], control_star[1:]
+
+        x0_star, eta_star = jax.vmap(_one)(batch.input, batch.mask)
+        return x0_star, eta_star
+
+    def as_analysis_step(self) -> _WeakFourDVarAnalysisStep:
+        return _WeakFourDVarAnalysisStep(self)
+
+
+def _accepts_mask(obs_op: Any) -> bool:
+    import inspect
+
+    try:
+        return "mask" in inspect.signature(obs_op.__call__).parameters
+    except (TypeError, ValueError):
+        return False
+
+
+class _WeakFourDVarAnalysisStep(eqx.Module):
+    """``pipekit_cycle.AnalysisStep`` adapter for ``WeakFourDVar``.
+
+    Returns the analysis initial state only (the model-error
+    trajectory is also available via direct ``model(batch)`` calls).
+    """
+
+    model: WeakFourDVar
+
+    def __call__(
+        self,
+        forecast: Float[Array, ...],
+        obs: Float[Array, ...],
+        *,
+        obs_op: Any,
+        obs_err_cov: Any,
+    ) -> Float[Array, ...]:
+        mask = jnp.where(jnp.isfinite(obs), 1.0, 0.0)
+        obs_clean = jnp.nan_to_num(obs)
+        batch = Batch1D(input=obs_clean, mask=mask, target=None)
+        x0_star, _ = self.model(batch)
+        return x0_star

--- a/src/vardax/_src/obs_operators/__init__.py
+++ b/src/vardax/_src/obs_operators/__init__.py
@@ -1,0 +1,42 @@
+"""Observation operator family.
+
+All operators satisfy ``pipekit_cycle.ObservationOperator`` directly
+(Decision D8): they implement ``__call__(state) -> obs`` and
+``linearize(state) -> AbstractLinearOperator``. The tangent-linear
+operator is used by incremental 4DVar (Epic 4) and posterior covariance
+computations (Epic 5).
+
+Decision D9 makes ``AveragingKernel`` and ``MultiInstrumentFusion``
+first-class day-one operators (not deferred to a later epic) since
+they're required for any RTM-derived L2 satellite product.
+
+Public surface:
+
+- :class:`MaskedIdentity`     — :math:`H(x) = m \\odot x`
+- :class:`LinearObs`          — :math:`H(x) = H_\\text{mat} \\cdot x`
+- :class:`AveragingKernel`    — :math:`H(x) = A(h \\cdot x + (1-h) x_a)`
+- :class:`MultiInstrumentFusion` — per-instrument composition at the
+  likelihood level
+- :class:`InstrumentRegistry` — :math:`\\{instrument\\_id : InstrumentSpec\\}`
+- :class:`InstrumentSpec`     — :math:`(obs\\_op, mask, R\\_op, id)` tuple
+"""
+
+from __future__ import annotations
+
+from .averaging_kernel import AveragingKernel
+from .linear import LinearObs
+from .masked import MaskedIdentity
+from .multi_instrument import (
+    InstrumentRegistry,
+    InstrumentSpec,
+    MultiInstrumentFusion,
+)
+
+__all__ = [
+    "AveragingKernel",
+    "InstrumentRegistry",
+    "InstrumentSpec",
+    "LinearObs",
+    "MaskedIdentity",
+    "MultiInstrumentFusion",
+]

--- a/src/vardax/_src/obs_operators/averaging_kernel.py
+++ b/src/vardax/_src/obs_operators/averaging_kernel.py
@@ -1,0 +1,75 @@
+"""Averaging-kernel observation operator (Decision D9).
+
+For RTM-derived L2 satellite products (TROPOMI CH₄, EMIT CH₄,
+OCO CO₂, MOPITT CO, …), the L2 retrieval is not a direct sample of
+the mixing-ratio profile :math:`x` — it smooths through a kernel
+matrix :math:`A` and falls back to a retrieval prior :math:`x_a`
+where the signal is weak:
+
+.. math::
+
+    \\hat y = A \\, (h \\odot x + (1 - h) \\odot x_a).
+
+Tangent-linear: :math:`H'(x) = A \\cdot \\mathrm{diag}(h)`.
+
+Skipping the averaging kernel is the most common cause of bias in
+operational satellite inversions; vardax exposes it as a first-class
+day-one operator (not a future feature).
+
+Satisfies ``pipekit_cycle.ObservationOperator``.
+"""
+
+from __future__ import annotations
+
+import equinox as eqx
+import jax.numpy as jnp
+from jaxtyping import Array, Float
+import lineax as lx
+
+
+class AveragingKernel(eqx.Module):
+    """RTM L2-style averaging-kernel obs operator.
+
+    Attributes:
+        A: Averaging kernel matrix, stored as an
+            ``lineax.AbstractLinearOperator``. May be ``MatrixLinearOperator``
+            for dense kernels or a structured operator (Kronecker for
+            separable kernels, LowRank for retrievals with low DOF).
+        x_a: Retrieval prior, same shape as the model state.
+        h: Weighting vector (often pressure-weighted).
+    """
+
+    A: lx.AbstractLinearOperator
+    x_a: Float[Array, N]  # ty:ignore[unresolved-reference]
+    h: Float[Array, N]  # ty:ignore[unresolved-reference]
+
+    def __call__(self, x: Float[Array, N]) -> Float[Array, N]:  # ty:ignore[unresolved-reference]
+        inner = self.h * x + (1.0 - self.h) * self.x_a
+        return self.A.mv(inner)
+
+    def linearize(self, x: Float[Array, N]) -> lx.AbstractLinearOperator:  # ty:ignore[unresolved-reference]
+        """Tangent-linear operator at ``x``: :math:`A \\cdot \\mathrm{diag}(h)`."""
+        diag_h = lx.DiagonalLinearOperator(self.h)
+        return self.A @ diag_h
+
+
+def averaging_kernel_from_l2(
+    A_matrix: Float[Array, "N N"],
+    x_a: Float[Array, N],  # ty:ignore[unresolved-reference]
+    h: Float[Array, N],  # ty:ignore[unresolved-reference]
+) -> AveragingKernel:
+    """Convenience constructor from a dense averaging-kernel matrix.
+
+    Wraps the dense matrix in ``lineax.MatrixLinearOperator`` so it
+    satisfies the same interface as structured kernels.
+
+    Args:
+        A_matrix: Dense averaging-kernel matrix of shape ``(N, N)``.
+        x_a: Retrieval prior of shape ``(N,)``.
+        h: Weighting vector of shape ``(N,)``.
+
+    Returns:
+        Configured ``AveragingKernel`` instance.
+    """
+    A = lx.MatrixLinearOperator(jnp.asarray(A_matrix))
+    return AveragingKernel(A=A, x_a=jnp.asarray(x_a), h=jnp.asarray(h))

--- a/src/vardax/_src/obs_operators/linear.py
+++ b/src/vardax/_src/obs_operators/linear.py
@@ -1,0 +1,28 @@
+"""Linear-projection observation operator.
+
+``H(x) = H_mat @ x`` where ``H_mat`` is supplied as a
+``lineax.AbstractLinearOperator`` so structure (sparse, low-rank,
+Kronecker) can be exploited without materialising the dense matrix.
+
+Use cases: Lagrangian footprint matrices, spectral filtering, spatial
+interpolation projections.
+"""
+
+from __future__ import annotations
+
+import equinox as eqx
+from jaxtyping import Array, Float
+import lineax as lx
+
+
+class LinearObs(eqx.Module):
+    """``H(x) = H_mat @ x``."""
+
+    H_mat: lx.AbstractLinearOperator
+
+    def __call__(self, x: Float[Array, ...]) -> Float[Array, ...]:
+        return self.H_mat.mv(x)
+
+    def linearize(self, x: Float[Array, ...]) -> lx.AbstractLinearOperator:
+        """Tangent-linear operator at ``x``: just ``H_mat`` (linear)."""
+        return self.H_mat

--- a/src/vardax/_src/obs_operators/masked.py
+++ b/src/vardax/_src/obs_operators/masked.py
@@ -1,0 +1,34 @@
+"""Masked-identity observation operator.
+
+The default operator for "we observe the state with gaps" use cases:
+SSH altimetry along-track gaps, SST with cloud masks, sparse in-situ.
+
+Satisfies ``pipekit_cycle.ObservationOperator``.
+"""
+
+from __future__ import annotations
+
+import equinox as eqx
+from jaxtyping import Array, Float
+import lineax as lx
+
+
+class MaskedIdentity(eqx.Module):
+    """:math:`H(x) = m \\odot x` with optional element-wise mask.
+
+    Stateless: no parameters. The mask can be supplied at call time
+    (per-batch) rather than baked in.
+    """
+
+    def __call__(
+        self,
+        x: Float[Array, ...],
+        mask: Float[Array, ...] | None = None,
+    ) -> Float[Array, ...]:
+        if mask is None:
+            return x
+        return x * mask
+
+    def linearize(self, x: Float[Array, ...]) -> lx.AbstractLinearOperator:
+        """Tangent-linear operator at ``x``: identity (since :math:`H` is linear)."""
+        return lx.JacobianLinearOperator(lambda y, _args=None: y, x)

--- a/src/vardax/_src/obs_operators/multi_instrument.py
+++ b/src/vardax/_src/obs_operators/multi_instrument.py
@@ -1,0 +1,137 @@
+"""Multi-instrument observation-operator fusion (Decision D9).
+
+Operational satellite work combines multiple instruments. Each has
+its own :math:`H_i`, mask :math:`m_i`, error covariance :math:`R_i`,
+and possibly its own averaging kernel. ``MultiInstrumentFusion``
+composes per-instrument operators at the **likelihood level** — no
+pre-regridding to a common grid, no assumption of shared coordinate
+systems.
+
+The fused observation cost:
+
+.. math::
+
+    J_\\text{obs}(x) = \\sum_{i \\in \\mathcal{I}} \\alpha_i \\cdot
+                       \\tfrac{1}{2} \\|m_i \\odot (y_i - H_i(x))\\|^2_{R_i^{-1}}.
+
+This module ships:
+
+- :class:`InstrumentSpec`     — :math:`(obs\\_op, mask, R\\_op, id)` tuple
+- :class:`InstrumentRegistry` — :math:`\\{instrument\\_id : InstrumentSpec\\}`
+- :class:`MultiInstrumentFusion` — composes the registry; returns
+  per-instrument ``dict[str, Array]`` of predicted observations. For
+  strict-protocol contexts (``pipekit_cycle.ObservationOperator``), the
+  ``.to_observation_operator()`` adapter flattens to a single output
+  with a block-diagonal linear operator.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import equinox as eqx
+import jax.numpy as jnp
+from jaxtyping import Array, Float
+import lineax as lx
+
+
+class InstrumentSpec(eqx.Module):
+    """Per-instrument ``(obs_op, mask, R_op, id)`` bundle.
+
+    Attributes:
+        obs_op: ``ObservationOperator``-conforming operator (typically
+            :class:`AveragingKernel`).
+        mask: Quality mask of shape compatible with the instrument's
+            observation space. ``1`` for valid pixels, ``0`` for
+            flagged/dropped.
+        R_op: Observation-error covariance as a
+            ``lineax.AbstractLinearOperator``. Often a
+            ``DiagonalLinearOperator`` keyed on the per-pixel
+            retrieval uncertainty.
+        instrument_id: Identifier (e.g. ``"TROPOMI"``, ``"EMIT"``,
+            ``"GHGSat"``).
+    """
+
+    obs_op: Any  # ObservationOperator (we don't import the Protocol to avoid a cycle)
+    mask: Float[Array, ...]
+    R_op: lx.AbstractLinearOperator
+    instrument_id: str = eqx.field(static=True)
+
+
+class InstrumentRegistry(eqx.Module):
+    """Keyed lookup of ``InstrumentSpec`` by ``instrument_id``.
+
+    Attributes:
+        entries: ``dict[instrument_id, InstrumentSpec]``.
+    """
+
+    entries: dict[str, InstrumentSpec] = eqx.field(default_factory=dict)
+
+
+class MultiInstrumentFusion(eqx.Module):
+    """Compose per-instrument operators at the likelihood level.
+
+    ``__call__`` returns ``dict[instrument_id, predicted_obs]`` — one
+    array per instrument. The cost function consumes the dict and
+    sums per-instrument terms with their respective :math:`R_i^{-1}`.
+    There is no shared coordinate system; each instrument keeps its
+    native footprint and resolution.
+
+    For strict ``pipekit_cycle.ObservationOperator`` contexts where a
+    single observation vector + single linear operator are required,
+    call ``.to_observation_operator()`` for a flattened wrapper.
+
+    Attributes:
+        registry: Per-instrument :class:`InstrumentRegistry`.
+        weights: Optional ``{instrument_id: alpha}`` mapping. ``None``
+            ⇒ uniform :math:`\\alpha_i = 1`.
+    """
+
+    registry: InstrumentRegistry
+    weights: dict[str, float] | None = None
+
+    def __call__(self, x: Float[Array, ...]) -> dict[str, Float[Array, ...]]:
+        return {
+            inst_id: spec.obs_op(x) for inst_id, spec in self.registry.entries.items()
+        }
+
+    def linearize(self, x: Float[Array, ...]) -> dict[str, lx.AbstractLinearOperator]:
+        """Per-instrument tangent-linear operators.
+
+        Returns ``{instrument_id: H_i'(x)}``. The fused tangent linear
+        is the block-diagonal stack of these — assembled lazily by
+        the cost function or via ``to_observation_operator()``.
+        """
+        return {
+            inst_id: spec.obs_op.linearize(x)
+            for inst_id, spec in self.registry.entries.items()
+        }
+
+    def to_observation_operator(self) -> _FlattenedMultiInstrument:
+        """Adapt to the strict ``pipekit_cycle.ObservationOperator`` protocol.
+
+        Returns a wrapper that concatenates per-instrument outputs and
+        exposes a block-diagonal linear operator. Use this when the
+        consumer requires a single ``(state) -> Array`` signature.
+        """
+        return _FlattenedMultiInstrument(fusion=self)
+
+
+class _FlattenedMultiInstrument(eqx.Module):
+    """``ObservationOperator``-compliant flattening of ``MultiInstrumentFusion``.
+
+    Concatenates per-instrument observations along axis 0; the
+    tangent-linear becomes a vertical stack of the per-instrument
+    Jacobians.
+    """
+
+    fusion: MultiInstrumentFusion
+
+    def __call__(self, x: Float[Array, ...]) -> Float[Array, ...]:
+        per_inst = self.fusion(x)
+        return jnp.concatenate([per_inst[k].ravel() for k in sorted(per_inst)], axis=0)
+
+    def linearize(self, x: Float[Array, ...]) -> lx.AbstractLinearOperator:
+        # Stack the per-instrument Jacobians as a block via JacobianLinearOperator
+        # on the flattened forward map.
+        return lx.JacobianLinearOperator(self.__call__, x)

--- a/src/vardax/_src/posterior/__init__.py
+++ b/src/vardax/_src/posterior/__init__.py
@@ -1,0 +1,32 @@
+"""Posterior adapters (Decision D10).
+
+Every vardax analysis emits a ``Posterior`` container — not just a
+point estimate. Three adapter families compute the posterior covariance
+via different approximations:
+
+- :class:`LaplaceCovariance`   — :math:`P^* = (B^{-1} + H^\\top R^{-1} H)^{-1}`
+  at MAP. Cheap, Gaussian-likelihood-only.
+- :class:`GaussNewtonHessian`  — Krylov / Lanczos inversion of the
+  Gauss-Newton Hessian. Exact at MAP, structured.
+- :class:`EnsembleCovariance`  — sample covariance from an ensemble of
+  analyses (delegates to ``filterax`` when supplied).
+
+Plus :class:`GaussianMarkLikelihood` — serialises a ``Posterior``
+to a JSON-friendly dict for downstream population models (Tier V).
+"""
+
+from __future__ import annotations
+
+from .adapter import GaussianMarkLikelihood
+from .container import Posterior
+from .ensemble import EnsembleCovariance
+from .gauss_newton import GaussNewtonHessian
+from .laplace import LaplaceCovariance
+
+__all__ = [
+    "EnsembleCovariance",
+    "GaussNewtonHessian",
+    "GaussianMarkLikelihood",
+    "LaplaceCovariance",
+    "Posterior",
+]

--- a/src/vardax/_src/posterior/adapter.py
+++ b/src/vardax/_src/posterior/adapter.py
@@ -1,0 +1,75 @@
+"""``GaussianMarkLikelihood`` — serialise a Posterior for downstream models.
+
+Per-event posteriors feed Tier V population models (TMTPP, hierarchical
+Bayesian) via a JSON-friendly mark-likelihood serialisation. The
+contract between the inference layer (vardax) and the audit /
+population layer (catalog / database / downstream model).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import equinox as eqx
+import jax.numpy as jnp
+import numpy as np
+
+from .container import Posterior
+
+
+class GaussianMarkLikelihood(eqx.Module):
+    """Serialise a Gaussian posterior into a mark-likelihood dict.
+
+    Attributes:
+        posterior: A vardax ``Posterior`` (with Gaussian ``cov``).
+        event_metadata: Free-form dict (event_id, time, geometry,
+            instruments_used, …). Passed through verbatim into the
+            output.
+
+    Use ``.to_dict()`` to get a JSON-friendly representation that
+    downstream consumers (GeoCatalog, hierarchical Bayesian models,
+    DuckDB ingest) can store as-is.
+    """
+
+    posterior: Posterior
+    event_metadata: dict[str, Any] = eqx.field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-friendly mark-likelihood representation."""
+        out: dict[str, Any] = {
+            "mean": _to_list(self.posterior.mean),
+            "cov_diag": (
+                _to_list(self._cov_diag()) if self.posterior.cov is not None else None
+            ),
+            "samples": (
+                _to_list(self.posterior.samples)
+                if self.posterior.samples is not None
+                else None
+            ),
+            "provenance": dict(self.posterior.provenance),
+            "event_metadata": dict(self.event_metadata),
+        }
+        return out
+
+    def _cov_diag(self):
+        """Extract the diagonal of the covariance operator.
+
+        For materialised operators this is cheap; for lazy operators
+        it costs one mat-vec per state dim (probe with unit vectors).
+        We pick the materialised path when the operator exposes it,
+        else fall back to a single ``as_matrix()`` call.
+        """
+        cov = self.posterior.cov
+        try:
+            return jnp.diag(cov.as_matrix())  # type: ignore[union-attr]  # ty:ignore[unresolved-attribute]
+        except (AttributeError, NotImplementedError):
+            # Lazy operators don't always materialise; just emit a
+            # null marker.
+            return None
+
+
+def _to_list(arr: Any) -> Any:
+    """JSON-safe conversion: numpy/jax arrays → nested lists."""
+    if arr is None:
+        return None
+    return np.asarray(arr).tolist()

--- a/src/vardax/_src/posterior/container.py
+++ b/src/vardax/_src/posterior/container.py
@@ -1,0 +1,38 @@
+"""``Posterior`` container — the standard output of every analysis.
+
+Carries the posterior mean, covariance (as an ``AbstractLinearOperator``
+when a Gaussian / Laplace approximation is used), optional ensemble
+samples, and provenance metadata for downstream auditing.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import equinox as eqx
+from jaxtyping import Array, Float
+import lineax as lx
+
+
+class Posterior(eqx.Module):
+    """Posterior container — Decision D10.
+
+    Attributes:
+        mean: Posterior mean / MAP estimate.
+        cov: Posterior covariance as ``lineax.AbstractLinearOperator``,
+            or ``None`` for amortized / sampling-only heads. Stored
+            lazily — never materialised into a dense matrix unless the
+            user asks.
+        samples: Optional ``(B, M, ...)`` posterior samples (from a
+            flow head, ensemble, or score-based diffusion). ``None``
+            for analytical adapters.
+        provenance: Free-form dict carrying audit info — at minimum
+            ``{forward_model_id, n_iter, J_star, converged,
+            vardax_version}``. Consumed by ``GaussianMarkLikelihood``
+            when serialising for downstream population models.
+    """
+
+    mean: Float[Array, ...]
+    cov: lx.AbstractLinearOperator | None = None
+    samples: Float[Array, ...] | None = None
+    provenance: dict[str, Any] = eqx.field(default_factory=dict)

--- a/src/vardax/_src/posterior/ensemble.py
+++ b/src/vardax/_src/posterior/ensemble.py
@@ -1,0 +1,85 @@
+"""Ensemble-covariance posterior adapter.
+
+Builds the posterior covariance from an ensemble of analyses
+(per perturbed initial condition or observation realisation):
+
+.. math::
+
+    P^* \\approx \\frac{1}{M-1} \\sum_m (x^{(m)} - \\bar x)(x^{(m)} - \\bar x)^\\top.
+
+When ``filterax`` is installed and used for the propagation, this
+adapter just packages the sample covariance into a ``Posterior``.
+Otherwise the user supplies the ensemble explicitly via the
+``analyses`` argument (shape ``(M, ...)``).
+
+Localisation and inflation are standard ensemble fixes — they live
+in ``filterax`` and aren't reimplemented here.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import equinox as eqx
+import jax.numpy as jnp
+from jaxtyping import Array, Float
+import lineax as lx
+
+from .container import Posterior
+
+
+class EnsembleCovariance(eqx.Module):
+    """Sample-covariance posterior from an ensemble of analyses.
+
+    Attributes:
+        n_members: Expected ensemble size (used for diagnostics).
+        inflation: Multiplicative inflation factor :math:`\\lambda` applied
+            to the sample covariance. Default 1.0 (no inflation).
+    """
+
+    n_members: int = eqx.field(static=True)
+    inflation: float = eqx.field(static=True, default=1.0)
+
+    def __call__(
+        self,
+        analyses: Float[Array, "M ..."],
+        model: Any,
+        batch: Any,
+    ) -> Posterior:
+        """Build the ensemble posterior from per-member analyses.
+
+        Args:
+            analyses: Stack of ``M`` analyses with shape ``(M, ...)``.
+            model: AnalysisStep instance (not used directly; kept for
+                interface compatibility).
+            batch: The batch (not used directly; kept for interface
+                compatibility).
+
+        Returns:
+            ``Posterior`` with mean = ensemble mean, ``cov`` = sample
+            covariance as a dense ``MatrixLinearOperator`` (only
+            assembled if you ask for it; safe for moderate M).
+        """
+        m = analyses.shape[0]
+        if m != self.n_members:
+            # Allow runtime mismatch; the configured ``n_members`` is
+            # advisory rather than enforced.
+            pass
+
+        mean = jnp.mean(analyses, axis=0)
+        # Flatten everything but the leading ensemble dim, then
+        # compute sample covariance.
+        flat = analyses.reshape(m, -1) - mean.reshape(1, -1)
+        cov_mat = self.inflation * (flat.T @ flat) / (m - 1)
+        cov_op = lx.MatrixLinearOperator(cov_mat, lx.positive_semidefinite_tag)
+
+        return Posterior(
+            mean=mean,
+            cov=cov_op,
+            samples=analyses,
+            provenance={
+                "adapter": "EnsembleCovariance",
+                "n_members": int(m),
+                "inflation": float(self.inflation),
+            },
+        )

--- a/src/vardax/_src/posterior/gauss_newton.py
+++ b/src/vardax/_src/posterior/gauss_newton.py
@@ -1,0 +1,77 @@
+"""Gauss-Newton Hessian posterior (Decision D10).
+
+For ``IncrementalFourDVar`` the Gauss-Newton Hessian is assembled
+during the last outer iteration as part of the algorithm. Reuse it
+for posterior covariance:
+
+.. math::
+
+    P^* = \\big(B^{-1} + \\sum_t (H'_t M'_t)^\\top R_t^{-1} (H'_t M'_t)\\big)^{-1}.
+
+For methods that don't assemble the GN Hessian as a side effect
+(``StrongFourDVar``, ``WeakFourDVar``), this adapter computes it
+on demand via Krylov / Lanczos over the same composed operator.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import equinox as eqx
+from jaxtyping import Array, Float
+import lineax as lx
+
+from .container import Posterior
+from .laplace import _inverse_op
+
+
+class GaussNewtonHessian(eqx.Module):
+    """Gauss-Newton Hessian inversion at MAP.
+
+    Functionally similar to ``LaplaceCovariance`` — both compute
+    :math:`(B^{-1} + H^\\top R^{-1} H)^{-1}` (or its 4D extension)
+    — but the GN-Hessian adapter is the recommended path for
+    ``IncrementalFourDVar`` where the Hessian is already
+    materialised by the inner CG solver.
+
+    Attributes:
+        prior_cov_op: :math:`B`.
+        obs_cov_op: :math:`R`.
+        n_krylov: Maximum Krylov iterations for mat-vec evaluations.
+    """
+
+    prior_cov_op: lx.AbstractLinearOperator
+    obs_cov_op: lx.AbstractLinearOperator
+    n_krylov: int = eqx.field(static=True, default=50)
+
+    def __call__(
+        self,
+        analysis: Float[Array, ...],
+        model: Any,
+        batch: Any,
+    ) -> Posterior:
+        """Build the GN-Hessian posterior at ``analysis``."""
+        underlying = getattr(model, "model", model)
+        obs_op = getattr(underlying, "obs_op", None)
+        if obs_op is None:
+            raise AttributeError(
+                "GaussNewtonHessian requires the model to expose `obs_op`."
+            )
+
+        H = obs_op.linearize(analysis)
+        precision = H.transpose() @ _inverse_op(self.obs_cov_op) @ H + _inverse_op(
+            self.prior_cov_op
+        )
+        precision_tagged = lx.TaggedLinearOperator(
+            precision, lx.positive_semidefinite_tag
+        )
+
+        return Posterior(
+            mean=analysis,
+            cov=_inverse_op(precision_tagged),
+            samples=None,
+            provenance={
+                "adapter": "GaussNewtonHessian",
+                "n_krylov": self.n_krylov,
+            },
+        )

--- a/src/vardax/_src/posterior/laplace.py
+++ b/src/vardax/_src/posterior/laplace.py
@@ -1,0 +1,126 @@
+"""Laplace approximation at MAP.
+
+For Gaussian-likelihood / Gaussian-prior problems at the MAP
+:math:`x^*`:
+
+.. math::
+
+    P^* \\approx \\big((H')^\\top R^{-1} H' + B^{-1}\\big)^{-1}.
+
+The result is returned as an ``AbstractLinearOperator`` so mat-vec
+(samples, marginals) compose lazily via ``lineax.CG`` without
+materialising :math:`P^*`.
+
+Use when:
+
+- Gaussian likelihood + Gaussian prior + single posterior mode
+  (verified by SBC).
+- Default for ``ThreeDVar``, ``StrongFourDVar``, ``WeakFourDVar``,
+  ``FourDVarNet``.
+
+For multimodal posteriors / non-Gaussian likelihoods, use
+``EnsembleCovariance``. For ``IncrementalFourDVar`` the
+``GaussNewtonHessian`` adapter reuses the Hessian assembled during
+the last outer iteration.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import equinox as eqx
+from jaxtyping import Array, Float
+import lineax as lx
+
+from .container import Posterior
+
+
+class LaplaceCovariance(eqx.Module):
+    """Laplace approximation at MAP.
+
+    Attributes:
+        prior_cov_op: Background-error covariance :math:`B`.
+        obs_cov_op: Observation-error covariance :math:`R`.
+
+    Both required so the adapter can build :math:`P^*` lazily. They
+    should match the operators used by the analysis method that
+    produced ``analysis``.
+    """
+
+    prior_cov_op: lx.AbstractLinearOperator
+    obs_cov_op: lx.AbstractLinearOperator
+
+    def __call__(
+        self,
+        analysis: Float[Array, ...],
+        model: Any,  # AnalysisStep-compliant
+        batch: Any,
+    ) -> Posterior:
+        """Build the Laplace posterior at ``analysis``.
+
+        Args:
+            analysis: MAP / posterior mean.
+            model: The analysis-step instance (used to recover the
+                observation operator). Expected to have a ``.model``
+                or be the underlying ``eqx.Module`` directly.
+            batch: The batch the analysis was computed against (used
+                to recover the mask, instrument bookkeeping, etc.).
+
+        Returns:
+            ``Posterior`` with ``mean = analysis`` and ``cov`` as a
+            lazy ``AbstractLinearOperator`` representing :math:`P^*`.
+        """
+        # Pull the obs operator off either an .as_analysis_step()
+        # wrapper or the raw model. Both expose ``obs_op``.
+        underlying = getattr(model, "model", model)
+        obs_op = getattr(underlying, "obs_op", None)
+        if obs_op is None:
+            raise AttributeError(
+                "LaplaceCovariance requires the model to expose `obs_op`; "
+                "got a model without one."
+            )
+
+        H = obs_op.linearize(analysis)
+        # P*^{-1} = H^T R^{-1} H + B^{-1}
+        # Build lazily — represent as the inverse of a composed
+        # AbstractLinearOperator. Concrete mat-vec evaluation is via
+        # lineax.CG on the precision operator.
+        precision = H.transpose() @ _inverse_op(self.obs_cov_op) @ H + _inverse_op(
+            self.prior_cov_op
+        )
+        precision_tagged = lx.TaggedLinearOperator(
+            precision, lx.positive_semidefinite_tag
+        )
+
+        return Posterior(
+            mean=analysis,
+            cov=_InverseLinearOperator(precision_tagged),
+            samples=None,
+            provenance={"adapter": "LaplaceCovariance"},
+        )
+
+
+def _inverse_op(op: lx.AbstractLinearOperator) -> lx.AbstractLinearOperator:
+    """Lazy inverse: a wrapper that applies ``op^{-1}`` via lineax.CG."""
+    return _InverseLinearOperator(
+        lx.TaggedLinearOperator(op, lx.positive_semidefinite_tag)
+    )
+
+
+class _InverseLinearOperator(lx.FunctionLinearOperator):
+    """Inverse of a positive-semidefinite operator, applied via CG.
+
+    Wraps any ``AbstractLinearOperator`` ``A`` such that mat-vec
+    returns ``A^{-1} v`` (solved by ``lineax.CG``). The inverse is
+    never materialised.
+    """
+
+    def __init__(self, op: lx.AbstractLinearOperator) -> None:
+        def _solve(v: Float[Array, ...]) -> Float[Array, ...]:
+            return lx.linear_solve(
+                op, v, solver=lx.CG(atol=1e-6, rtol=1e-6, max_steps=200)
+            ).value
+
+        # FunctionLinearOperator needs an input_structure; reuse the
+        # underlying operator's.
+        super().__init__(_solve, op.in_structure())

--- a/src/vardax/_src/priors.py
+++ b/src/vardax/_src/priors.py
@@ -1,32 +1,40 @@
-"""Learned prior models for 4DVarNet.
+"""Learned prior models for FourDVarNet.
 
-All priors are implemented as Flax NNX modules with an ``encode`` /
-``decode`` interface (bilinear autoencoder) or a simple forward pass that
-returns the autoencoder reconstruction.
+All priors are implemented as Equinox modules. They expose a single
+``__call__`` returning the reconstructed state; bilinear / MLP /
+convolutional autoencoder variants are provided for 1D and 2D spatial
+data with optional time and channel axes.
 """
 
 from __future__ import annotations
 
-from flax import nnx
+import equinox as eqx
 import jax
 import jax.numpy as jnp
-from jaxtyping import Array, Float
+from jaxtyping import Array, Float, PRNGKeyArray
 
 # ---------------------------------------------------------------------------
 # Helper layers
 # ---------------------------------------------------------------------------
 
 
-class _BilinearBlock(nnx.Module):
+class _BilinearBlock(eqx.Module):
     """Single bilinear block: relu(Ax) * tanh(Bx)."""
 
-    def __init__(self, in_features: int, out_features: int, rngs: nnx.Rngs) -> None:
-        self.linear_a = nnx.Linear(in_features, out_features, rngs=rngs)
-        self.linear_b = nnx.Linear(in_features, out_features, rngs=rngs)
+    linear_a: eqx.nn.Linear
+    linear_b: eqx.nn.Linear
+
+    def __init__(
+        self, in_features: int, out_features: int, *, key: PRNGKeyArray
+    ) -> None:
+        key_a, key_b = jax.random.split(key)
+        self.linear_a = eqx.nn.Linear(in_features, out_features, key=key_a)
+        self.linear_b = eqx.nn.Linear(in_features, out_features, key=key_b)
 
     def __call__(self, x: Array) -> Array:
-        a = self.linear_a(x)
-        b = self.linear_b(x)
+        # eqx.nn.Linear operates on a single sample, vmap over batch
+        a = jax.vmap(self.linear_a)(x)
+        b = jax.vmap(self.linear_b)(x)
         return jax.nn.relu(a) * jnp.tanh(b)
 
 
@@ -35,11 +43,11 @@ class _BilinearBlock(nnx.Module):
 # ---------------------------------------------------------------------------
 
 
-class BilinAEPrior1D(nnx.Module):
+class BilinAEPrior1D(eqx.Module):
     """Bilinear autoencoder prior for 1-D data.
 
     The encoder maps the input to a low-dimensional latent code; the decoder
-    reconstructs the original space.  The prior cost is
+    reconstructs the original space. The prior cost is
     ``||x - decode(encode(x))||^2``.
 
     Attributes:
@@ -48,26 +56,33 @@ class BilinAEPrior1D(nnx.Module):
         n_time: Number of time steps (``T``).
     """
 
+    state_dim: int = eqx.field(static=True)
+    latent_dim: int = eqx.field(static=True)
+    n_time: int = eqx.field(static=True)
+    _bilin: _BilinearBlock
+    _decode_dense: eqx.nn.Linear
+
     def __init__(
         self,
         state_dim: int,
         latent_dim: int,
         n_time: int = 1,
         *,
-        rngs: nnx.Rngs,
+        key: PRNGKeyArray,
     ) -> None:
         self.state_dim = state_dim
         self.latent_dim = latent_dim
         self.n_time = n_time
         in_features = n_time * state_dim
-        self._bilin = _BilinearBlock(in_features, latent_dim, rngs)
-        self._decode_dense = nnx.Linear(latent_dim, n_time * state_dim, rngs=rngs)
+        key_bilin, key_dec = jax.random.split(key)
+        self._bilin = _BilinearBlock(in_features, latent_dim, key=key_bilin)
+        self._decode_dense = eqx.nn.Linear(latent_dim, n_time * state_dim, key=key_dec)
 
     def __call__(self, x: Float[Array, "B T N"]) -> Float[Array, "B T N"]:
         b, t, n = x.shape
         x_flat = x.reshape(b, t * n)
         z = self._bilin(x_flat)
-        out = self._decode_dense(z)
+        out = jax.vmap(self._decode_dense)(z)
         return out.reshape(b, t, n)
 
     def encode(self, x: Float[Array, "B T N"]) -> Float[Array, "B Z"]:
@@ -78,11 +93,11 @@ class BilinAEPrior1D(nnx.Module):
 
     def decode(self, z: Float[Array, "B Z"]) -> Float[Array, "B T N"]:
         """Decode latent code to state space."""
-        out = self._decode_dense(z)
+        out = jax.vmap(self._decode_dense)(z)
         return out.reshape(-1, self.n_time, self.state_dim)
 
 
-class MLPAEPrior1D(nnx.Module):
+class MLPAEPrior1D(eqx.Module):
     """MLP autoencoder prior for 1-D data.
 
     Attributes:
@@ -92,6 +107,12 @@ class MLPAEPrior1D(nnx.Module):
         n_time: Number of time steps (``T``).
     """
 
+    n_time: int = eqx.field(static=True)
+    enc1: eqx.nn.Linear
+    enc2: eqx.nn.Linear
+    dec1: eqx.nn.Linear
+    dec2: eqx.nn.Linear
+
     def __init__(
         self,
         state_dim: int,
@@ -99,26 +120,27 @@ class MLPAEPrior1D(nnx.Module):
         hidden_dim: int = 64,
         n_time: int = 1,
         *,
-        rngs: nnx.Rngs,
+        key: PRNGKeyArray,
     ) -> None:
         self.n_time = n_time
         in_features = n_time * state_dim
-        self.enc1 = nnx.Linear(in_features, hidden_dim, rngs=rngs)
-        self.enc2 = nnx.Linear(hidden_dim, latent_dim, rngs=rngs)
-        self.dec1 = nnx.Linear(latent_dim, hidden_dim, rngs=rngs)
-        self.dec2 = nnx.Linear(hidden_dim, in_features, rngs=rngs)
+        k1, k2, k3, k4 = jax.random.split(key, 4)
+        self.enc1 = eqx.nn.Linear(in_features, hidden_dim, key=k1)
+        self.enc2 = eqx.nn.Linear(hidden_dim, latent_dim, key=k2)
+        self.dec1 = eqx.nn.Linear(latent_dim, hidden_dim, key=k3)
+        self.dec2 = eqx.nn.Linear(hidden_dim, in_features, key=k4)
 
     def __call__(self, x: Float[Array, "B T N"]) -> Float[Array, "B T N"]:
         b, t, n = x.shape
         x_flat = x.reshape(b, t * n)
-        z = jax.nn.relu(self.enc1(x_flat))
-        z = self.enc2(z)
-        h = jax.nn.relu(self.dec1(z))
-        out = self.dec2(h)
+        z = jax.nn.relu(jax.vmap(self.enc1)(x_flat))
+        z = jax.vmap(self.enc2)(z)
+        h = jax.nn.relu(jax.vmap(self.dec1)(z))
+        out = jax.vmap(self.dec2)(h)
         return out.reshape(b, t, n)
 
 
-class BilinAEPrior2D(nnx.Module):
+class BilinAEPrior2D(eqx.Module):
     """Bilinear autoencoder prior for 2-D data.
 
     Attributes:
@@ -128,6 +150,12 @@ class BilinAEPrior2D(nnx.Module):
         width: Spatial width ``W``.
     """
 
+    n_time: int = eqx.field(static=True)
+    height: int = eqx.field(static=True)
+    width: int = eqx.field(static=True)
+    _bilin: _BilinearBlock
+    _decode_dense: eqx.nn.Linear
+
     def __init__(
         self,
         latent_dim: int,
@@ -135,24 +163,25 @@ class BilinAEPrior2D(nnx.Module):
         height: int,
         width: int,
         *,
-        rngs: nnx.Rngs,
+        key: PRNGKeyArray,
     ) -> None:
         self.n_time = n_time
         self.height = height
         self.width = width
         in_features = n_time * height * width
-        self._bilin = _BilinearBlock(in_features, latent_dim, rngs)
-        self._decode_dense = nnx.Linear(latent_dim, in_features, rngs=rngs)
+        k_bilin, k_dec = jax.random.split(key)
+        self._bilin = _BilinearBlock(in_features, latent_dim, key=k_bilin)
+        self._decode_dense = eqx.nn.Linear(latent_dim, in_features, key=k_dec)
 
     def __call__(self, x: Float[Array, "B T H W"]) -> Float[Array, "B T H W"]:
         b, t, h, w = x.shape
         x_flat = x.reshape(b, t * h * w)
         z = self._bilin(x_flat)
-        out = self._decode_dense(z)
+        out = jax.vmap(self._decode_dense)(z)
         return out.reshape(b, t, h, w)
 
 
-class BilinAEPrior2DMultivar(nnx.Module):
+class BilinAEPrior2DMultivar(eqx.Module):
     """Bilinear autoencoder prior for 2-D multivariate data.
 
     Attributes:
@@ -163,6 +192,13 @@ class BilinAEPrior2DMultivar(nnx.Module):
         width: Spatial width ``W``.
     """
 
+    n_time: int = eqx.field(static=True)
+    n_channels: int = eqx.field(static=True)
+    height: int = eqx.field(static=True)
+    width: int = eqx.field(static=True)
+    _bilin: _BilinearBlock
+    _decode_dense: eqx.nn.Linear
+
     def __init__(
         self,
         latent_dim: int,
@@ -171,21 +207,22 @@ class BilinAEPrior2DMultivar(nnx.Module):
         height: int,
         width: int,
         *,
-        rngs: nnx.Rngs,
+        key: PRNGKeyArray,
     ) -> None:
         self.n_time = n_time
         self.n_channels = n_channels
         self.height = height
         self.width = width
         in_features = n_time * n_channels * height * width
-        self._bilin = _BilinearBlock(in_features, latent_dim, rngs)
-        self._decode_dense = nnx.Linear(latent_dim, in_features, rngs=rngs)
+        k_bilin, k_dec = jax.random.split(key)
+        self._bilin = _BilinearBlock(in_features, latent_dim, key=k_bilin)
+        self._decode_dense = eqx.nn.Linear(latent_dim, in_features, key=k_dec)
 
     def __call__(self, x: Float[Array, "B T C H W"]) -> Float[Array, "B T C H W"]:
         b, t, c, h, w = x.shape
         x_flat = x.reshape(b, t * c * h * w)
         z = self._bilin(x_flat)
-        out = self._decode_dense(z)
+        out = jax.vmap(self._decode_dense)(z)
         return out.reshape(b, t, c, h, w)
 
 
@@ -194,36 +231,29 @@ class BilinAEPrior2DMultivar(nnx.Module):
 # ---------------------------------------------------------------------------
 
 
-class IdentityPrior(nnx.Module):
+class IdentityPrior(eqx.Module):
     """Trivial identity prior: :math:`\\varphi(x) = x`.
 
-    Acts as a pure observation-driven baseline where the prior term
-    contributes zero cost regardless of the state, and is also useful
-    as a sanity-check building block in tests.
+    Zero parameters. Useful as a pure obs-driven baseline (the prior
+    cost vanishes everywhere) and as a sanity-check building block in
+    the linear-Gaussian agreement tests.
     """
 
     def __call__(self, x: Float[Array, ...]) -> Float[Array, ...]:
-        """Return the input unchanged.
-
-        Args:
-            x: Input array of arbitrary shape.
-
-        Returns:
-            The same array ``x``.
-        """
+        """Return the input unchanged."""
         return x
 
 
 # ---------------------------------------------------------------------------
-# Lorenz-63 prior
+# Lorenz priors
 # ---------------------------------------------------------------------------
 
 
-class L63Prior(nnx.Module):
+class L63Prior(eqx.Module):
     """Learned prior for the Lorenz-63 system.
 
     A simple MLP autoencoder designed for the 3-dimensional Lorenz-63
-    attractor.  The state is treated as a flat vector of length ``3``.
+    attractor. The state is treated as a flat vector of length ``3``.
 
     Attributes:
         latent_dim: Dimensionality of the latent code (default ``3``).
@@ -231,36 +261,37 @@ class L63Prior(nnx.Module):
         state_dim: Dimensionality of the state vector (default ``3``).
     """
 
+    enc1: eqx.nn.Linear
+    enc2: eqx.nn.Linear
+    dec1: eqx.nn.Linear
+    dec2: eqx.nn.Linear
+
     def __init__(
         self,
         latent_dim: int = 3,
         hidden_dim: int = 32,
         state_dim: int = 3,
         *,
-        rngs: nnx.Rngs,
+        key: PRNGKeyArray,
     ) -> None:
-        self.enc1 = nnx.Linear(state_dim, hidden_dim, rngs=rngs)
-        self.enc2 = nnx.Linear(hidden_dim, latent_dim, rngs=rngs)
-        self.dec1 = nnx.Linear(latent_dim, hidden_dim, rngs=rngs)
-        self.dec2 = nnx.Linear(hidden_dim, state_dim, rngs=rngs)
+        k1, k2, k3, k4 = jax.random.split(key, 4)
+        self.enc1 = eqx.nn.Linear(state_dim, hidden_dim, key=k1)
+        self.enc2 = eqx.nn.Linear(hidden_dim, latent_dim, key=k2)
+        self.dec1 = eqx.nn.Linear(latent_dim, hidden_dim, key=k3)
+        self.dec2 = eqx.nn.Linear(hidden_dim, state_dim, key=k4)
 
     def __call__(self, x: Float[Array, "B N"]) -> Float[Array, "B N"]:
-        z = jnp.tanh(self.enc1(x))
-        z = self.enc2(z)
-        h = jnp.tanh(self.dec1(z))
-        return self.dec2(h)
+        z = jnp.tanh(jax.vmap(self.enc1)(x))
+        z = jax.vmap(self.enc2)(z)
+        h = jnp.tanh(jax.vmap(self.dec1)(z))
+        return jax.vmap(self.dec2)(h)
 
 
-# ---------------------------------------------------------------------------
-# Lorenz-96 priors
-# ---------------------------------------------------------------------------
-
-
-class L96Prior(nnx.Module):
+class L96Prior(eqx.Module):
     """Learned prior for the Lorenz-96 system.
 
     A simple MLP autoencoder designed for the N-dimensional Lorenz-96
-    attractor.  The state is treated as a flat vector of length ``N``.
+    attractor. The state is treated as a flat vector of length ``N``.
 
     Attributes:
         latent_dim: Dimensionality of the latent code.
@@ -268,31 +299,37 @@ class L96Prior(nnx.Module):
         state_dim: Dimensionality of the state vector.
     """
 
+    enc1: eqx.nn.Linear
+    enc2: eqx.nn.Linear
+    dec1: eqx.nn.Linear
+    dec2: eqx.nn.Linear
+
     def __init__(
         self,
         latent_dim: int = 16,
         hidden_dim: int = 64,
         state_dim: int = 40,
         *,
-        rngs: nnx.Rngs,
+        key: PRNGKeyArray,
     ) -> None:
-        self.enc1 = nnx.Linear(state_dim, hidden_dim, rngs=rngs)
-        self.enc2 = nnx.Linear(hidden_dim, latent_dim, rngs=rngs)
-        self.dec1 = nnx.Linear(latent_dim, hidden_dim, rngs=rngs)
-        self.dec2 = nnx.Linear(hidden_dim, state_dim, rngs=rngs)
+        k1, k2, k3, k4 = jax.random.split(key, 4)
+        self.enc1 = eqx.nn.Linear(state_dim, hidden_dim, key=k1)
+        self.enc2 = eqx.nn.Linear(hidden_dim, latent_dim, key=k2)
+        self.dec1 = eqx.nn.Linear(latent_dim, hidden_dim, key=k3)
+        self.dec2 = eqx.nn.Linear(hidden_dim, state_dim, key=k4)
 
     def __call__(self, x: Float[Array, "B N"]) -> Float[Array, "B N"]:
-        z = jnp.tanh(self.enc1(x))
-        z = self.enc2(z)
-        h = jnp.tanh(self.dec1(z))
-        return self.dec2(h)
+        z = jnp.tanh(jax.vmap(self.enc1)(x))
+        z = jax.vmap(self.enc2)(z)
+        h = jnp.tanh(jax.vmap(self.dec1)(z))
+        return jax.vmap(self.dec2)(h)
 
 
-class ConvAEPrior1D(nnx.Module):
+class ConvAEPrior1D(eqx.Module):
     """Convolutional autoencoder prior for 1-D spatially-structured data.
 
     Uses circular (periodic) padding suitable for systems with periodic
-    boundary conditions such as Lorenz-96.  Operates on inputs of shape
+    boundary conditions such as Lorenz-96. Operates on inputs of shape
     ``(B, T, N)`` where ``N`` is the spatial dimension.
 
     Attributes:
@@ -302,13 +339,18 @@ class ConvAEPrior1D(nnx.Module):
             and validated against the runtime input shape.
     """
 
+    kernel_size: int = eqx.field(static=True)
+    n_time: int = eqx.field(static=True)
+    _enc_conv: eqx.nn.Conv1d
+    _dec_conv: eqx.nn.Conv1d
+
     def __init__(
         self,
         latent_channels: int = 16,
         kernel_size: int = 3,
         n_time: int = 1,
         *,
-        rngs: nnx.Rngs,
+        key: PRNGKeyArray,
     ) -> None:
         if kernel_size <= 0 or kernel_size % 2 == 0:
             raise ValueError(
@@ -316,12 +358,21 @@ class ConvAEPrior1D(nnx.Module):
             )
         self.kernel_size = kernel_size
         self.n_time = n_time
-        ksize = (kernel_size,)
-        self._enc_conv = nnx.Conv(
-            n_time, latent_channels, kernel_size=ksize, padding="VALID", rngs=rngs
+        k_enc, k_dec = jax.random.split(key)
+        # eqx.nn.Conv1d uses channels-first: (in_channels, length)
+        self._enc_conv = eqx.nn.Conv1d(
+            in_channels=n_time,
+            out_channels=latent_channels,
+            kernel_size=kernel_size,
+            padding=0,  # we apply circular padding manually
+            key=k_enc,
         )
-        self._dec_conv = nnx.Conv(
-            latent_channels, n_time, kernel_size=ksize, padding="VALID", rngs=rngs
+        self._dec_conv = eqx.nn.Conv1d(
+            in_channels=latent_channels,
+            out_channels=n_time,
+            kernel_size=kernel_size,
+            padding=0,
+            key=k_dec,
         )
 
     def __call__(self, x: Float[Array, "B T N"]) -> Float[Array, "B T N"]:
@@ -330,20 +381,20 @@ class ConvAEPrior1D(nnx.Module):
             raise ValueError(
                 f"Input time dimension {t} does not match n_time={self.n_time}."
             )
-        # Treat time as channels: (B, N, T)
-        h = x.transpose((0, 2, 1))
-
-        # Circular padding for periodic boundaries (pad==0 when kernel_size==1)
+        # eqx Conv1d expects channels-first: (in_channels=T, length=N)
+        # x is already (B, T, N) so vmap over the batch dim works directly.
         pad = self.kernel_size // 2
-        if pad > 0:
-            h = jnp.concatenate([h[:, -pad:, :], h, h[:, :pad, :]], axis=1)
-        h = self._enc_conv(h)
-        h = jax.nn.relu(h)
 
-        # Decode: circular padding + conv back to n_time channels
-        if pad > 0:
-            h = jnp.concatenate([h[:, -pad:, :], h, h[:, :pad, :]], axis=1)
-        h = self._dec_conv(h)
+        def _forward(xi: Float[Array, "T N"]) -> Float[Array, "T N"]:
+            # Circular padding along spatial axis (axis=1)
+            if pad > 0:
+                h = jnp.concatenate([xi[:, -pad:], xi, xi[:, :pad]], axis=1)
+            else:
+                h = xi
+            h = self._enc_conv(h)
+            h = jax.nn.relu(h)
+            if pad > 0:
+                h = jnp.concatenate([h[:, -pad:], h, h[:, :pad]], axis=1)
+            return self._dec_conv(h)
 
-        # Back to (B, T, N)
-        return h.transpose((0, 2, 1))
+        return jax.vmap(_forward)(x)

--- a/src/vardax/_src/protocols.py
+++ b/src/vardax/_src/protocols.py
@@ -1,0 +1,147 @@
+"""Runtime-checkable protocols used across vardax.
+
+vardax re-exports the three core ``pipekit_cycle`` protocols
+(`ForwardModel`, `ObservationOperator`, `AnalysisStep`) and adds five
+vardax-specific protocols that ``pipekit-cycle`` doesn't name:
+
+- `Prior`            — :math:`\\varphi: x \\mapsto x_\\text{prior}`
+- `GradModulator`    — :math:`\\Phi: (\\nabla J, h) \\mapsto (\\Delta x, h')`
+- `CostFunction`     — :math:`J: (x, \\text{batch}) \\mapsto \\text{scalar}`
+- `PosteriorAdapter` — analysis output → ``Posterior``
+- `Minimiser`        — wraps `optimistix.AbstractMinimiser` over vardax's
+  cost-function interface
+
+All protocols are ``@runtime_checkable`` so ``isinstance(obj, Protocol)``
+works for structural conformance checking — used by
+``tests/test_pipekit_protocols.py``.
+
+The vardax-specific protocols are imported by Layer 1 components.
+``pipekit_cycle`` re-exports are imported by Layer 2 models that
+expose ``.as_analysis_step()``.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Protocol, runtime_checkable
+
+from jaxtyping import Array, Float
+
+# Re-export pipekit-cycle protocols — vardax models satisfy them structurally
+# (Decision D8: no parallel Abstract* hierarchy).
+from pipekit_cycle import (
+    AnalysisStep,
+    ForwardModel,
+    ObservationOperator,
+)
+
+
+@runtime_checkable
+class Prior(Protocol):
+    """Prior model: maps state to its regularised reconstruction.
+
+    For an autoencoder prior :math:`\\varphi_\\theta`, the variational
+    cost includes ``||x - φ(x)||^2``. For a dynamical prior wrapping a
+    `ForwardModel`, ``φ(x)`` is the forward integration. For the
+    identity prior, ``φ(x) = x``.
+
+    Members:
+        ``__call__(x) -> x_prior`` — apply the prior model.
+    """
+
+    def __call__(self, x: Float[Array, ...]) -> Float[Array, ...]: ...
+
+
+@runtime_checkable
+class GradModulator(Protocol):
+    """Learned gradient modulator for the FourDVarNet inner solver.
+
+    Takes the current variational-cost gradient and the modulator's
+    own carry state, returns a state update and the new carry. Used
+    only by `FourDVarNet`; the classical analysis methods use
+    ``optimistix.AbstractMinimiser`` instead.
+
+    Members:
+        ``__call__(grad, state, carry) -> (update, new_carry)``
+    """
+
+    def __call__(
+        self,
+        grad: Float[Array, ...],
+        state: Float[Array, ...],
+        carry: Any,
+    ) -> tuple[Float[Array, ...], Any]: ...
+
+
+@runtime_checkable
+class CostFunction(Protocol):
+    """Variational cost function ``J(x, batch, **kwargs) -> scalar``.
+
+    Implementations include `vardax.costs.ThreeDVarCost`,
+    `StrongConstraintCost`, `WeakConstraintCost`, `IncrementalCost`,
+    and `FourDVarNetCost`.
+
+    Members:
+        ``__call__(x, batch, **kwargs) -> scalar``
+    """
+
+    def __call__(
+        self,
+        x: Float[Array, ...],
+        batch: Any,
+        **kwargs: Any,
+    ) -> Float[Array, ""]: ...
+
+
+@runtime_checkable
+class PosteriorAdapter(Protocol):
+    """Turns an analysis output into a `Posterior` container.
+
+    Implementations: `LaplaceCovariance`, `GaussNewtonHessian`,
+    `EnsembleCovariance`. Each computes the posterior covariance via a
+    different approximation; the contract returned is the same.
+
+    Members:
+        ``__call__(analysis, model, batch) -> Posterior``
+    """
+
+    def __call__(
+        self,
+        analysis: Float[Array, ...],
+        model: AnalysisStep,
+        batch: Any,
+    ) -> Any: ...
+
+
+@runtime_checkable
+class Minimiser(Protocol):
+    """Wrapper protocol around ``optimistix.AbstractMinimiser``.
+
+    A `Minimiser` knows how to minimise a `CostFunction` from an
+    initial guess ``x0`` against a batch. Implementations adapt
+    optimistix solvers (GaussNewton, BFGS, NonlinearCG, …) to vardax's
+    cost-function calling convention.
+
+    Members:
+        ``__call__(cost_fn, x0, batch) -> x_star``
+    """
+
+    def __call__(
+        self,
+        cost_fn: CostFunction,
+        x0: Float[Array, ...],
+        batch: Any,
+    ) -> Float[Array, ...]: ...
+
+
+__all__ = [
+    # Re-exports from pipekit-cycle
+    "AnalysisStep",
+    "ForwardModel",
+    "ObservationOperator",
+    # Vardax-specific
+    "CostFunction",
+    "GradModulator",
+    "Minimiser",
+    "PosteriorAdapter",
+    "Prior",
+]

--- a/src/vardax/_src/solver.py
+++ b/src/vardax/_src/solver.py
@@ -6,8 +6,9 @@ the variational cost minimisation, guided by the learned gradient modulator.
 
 from __future__ import annotations
 
-from typing import Any, Literal, NamedTuple
+from typing import Any, Literal
 
+import equinox as eqx
 import jax
 import jax.numpy as jnp
 from jaxtyping import Array, Float
@@ -29,7 +30,7 @@ GradMode = Literal["unrolled", "implicit", "one_step"]
 # ---------------------------------------------------------------------------
 
 
-class SolverState1D(NamedTuple):
+class SolverState1D(eqx.Module):
     """Mutable solver state for 1-D problems.
 
     Attributes:
@@ -43,7 +44,7 @@ class SolverState1D(NamedTuple):
     step: int
 
 
-class SolverState2D(NamedTuple):
+class SolverState2D(eqx.Module):
     """Mutable solver state for 2-D problems.
 
     Attributes:

--- a/src/vardax/_src/solver.py
+++ b/src/vardax/_src/solver.py
@@ -6,7 +6,7 @@ the variational cost minimisation, guided by the learned gradient modulator.
 
 from __future__ import annotations
 
-from typing import Any, Literal
+from typing import Any
 
 import equinox as eqx
 import jax
@@ -15,15 +15,10 @@ from jaxtyping import Array, Float
 
 from ._types import Batch1D, Batch2D, LSTMState1D, LSTMState2D
 
-GradMode = Literal["unrolled", "implicit", "one_step"]
-"""Differentiation strategy for the 4DVarNet solver.
-
-- ``"unrolled"``: backprop through all ``K`` solver steps (O(K) memory).
-- ``"implicit"``:  fixed-point / implicit differentiation (O(1) memory,
-  requires the solver to have converged to a fixed point).
-- ``"one_step"``:  one-step differentiation (Bolte et al., NeurIPS 2023);
-  O(1) memory, only the last solver step is differentiated.
-"""
+# v0.4 removes the `GradMode` enum (`"unrolled" | "implicit" | "one_step"`).
+# Differentiation strategy is now selected via ``solver_adjoint`` on the
+# model — an ``optimistix.AbstractAdjoint`` instance. See
+# ``vardax.adjoints`` (Decision D15).
 
 # ---------------------------------------------------------------------------
 # Solver state containers

--- a/src/vardax/_src/training.py
+++ b/src/vardax/_src/training.py
@@ -1,23 +1,29 @@
-"""Training utilities for 4DVarNet.
+"""Training primitives for FourDVarNet.
 
-Provides loss functions, per-step training / evaluation functions, and a
-high-level ``fit`` loop compatible with Flax NNX and ``optax``.
+Per Decision D5, vardax ships ``train_step`` and ``eval_step`` as
+Layer 0 primitives — they encode the correctness-critical
+differentiation through the FourDVarNet inner solver, which is the part
+that's library-grade. The outer training loop (epoch iteration, logging,
+checkpointing, distributed) is delegated to ``pipekit-train``
+(``[train]`` extra) — see ``vardax.adapters.pipekit_train`` for the
+``Loss`` adapter that wraps ``train_loss_fn`` into the
+``pipekit_train.Loss`` protocol.
+
+This module contains *only* the inner-step primitives. There is no
+``fit()`` helper; users either compose ``train_step`` into a small
+notebook-level loop or wire it through ``pipekit_train.TrainingLoop``.
 """
 
 from __future__ import annotations
 
 from typing import Any
 
-from flax import nnx
+import equinox as eqx
 import jax.numpy as jnp
 from jaxtyping import Array, Float
 import optax
 
 from ._types import Batch1D, Batch2D
-
-# ---------------------------------------------------------------------------
-# Loss functions
-# ---------------------------------------------------------------------------
 
 
 def reconstruction_loss(
@@ -43,41 +49,51 @@ def train_loss_fn(
     """Compute the training loss for a single batch.
 
     Args:
-        model: Flax NNX module.
-        batch: Training batch.
+        model: Equinox module implementing ``__call__(batch) -> prediction``.
+        batch: Training batch (must have a non-``None`` ``target``).
 
     Returns:
         Scalar reconstruction loss.
     """
     pred = model(batch)
-    return reconstruction_loss(pred, batch.target)
+    target = batch.target
+    if target is None:
+        raise ValueError("train_loss_fn requires batch.target to be set.")
+    return reconstruction_loss(pred, target)
 
 
-# ---------------------------------------------------------------------------
-# Training / evaluation steps
-# ---------------------------------------------------------------------------
-
-
+@eqx.filter_jit
 def train_step(
     model: Any,
-    optimizer: nnx.Optimizer,
     batch: Batch1D | Batch2D,
-) -> Float[Array, ""]:
+    optimizer: optax.GradientTransformation,
+    opt_state: optax.OptState,
+) -> tuple[Any, optax.OptState, Float[Array, ""]]:
     """Perform a single training step (forward + backward + update).
 
+    This is the correctness-critical primitive: gradients flow through
+    the FourDVarNet inner solver according to whichever differentiation
+    strategy (``"unrolled"`` / ``"one_step"`` / ``"implicit"``) the
+    model is configured with. Users should compose this primitive into
+    their training loop (notebook-level or ``pipekit_train.TrainingLoop``)
+    rather than reimplementing it.
+
     Args:
-        model: Flax NNX module.
-        optimizer: NNX optimizer wrapping the model parameters.
+        model: Equinox module to optimise.
         batch: Training batch.
+        optimizer: Optax gradient transformation (e.g. ``optax.adam(1e-3)``).
+        opt_state: Current optimiser state.
 
     Returns:
-        Scalar training loss.
+        Tuple of (updated model, updated optimiser state, scalar loss).
     """
-    loss, grads = nnx.value_and_grad(train_loss_fn)(model, batch)
-    optimizer.update(model, grads)
-    return loss
+    loss, grads = eqx.filter_value_and_grad(train_loss_fn)(model, batch)
+    updates, opt_state = optimizer.update(grads, opt_state, model)
+    model = eqx.apply_updates(model, updates)
+    return model, opt_state, loss
 
 
+@eqx.filter_jit
 def eval_step(
     model: Any,
     batch: Batch1D | Batch2D,
@@ -85,71 +101,14 @@ def eval_step(
     """Compute the evaluation loss for a single batch (no gradient).
 
     Args:
-        model: Flax NNX module.
-        batch: Evaluation batch.
+        model: Equinox module.
+        batch: Evaluation batch (must have a non-``None`` ``target``).
 
     Returns:
         Scalar reconstruction loss.
     """
     pred = model(batch)
-    return reconstruction_loss(pred, batch.target)
-
-
-# ---------------------------------------------------------------------------
-# High-level fit loop
-# ---------------------------------------------------------------------------
-
-
-def fit(
-    model: Any,
-    train_batches: list[Batch1D | Batch2D],
-    *,
-    lr: float = 1e-3,
-    n_epochs: int = 10,
-    val_batches: list[Batch1D | Batch2D] | None = None,
-    verbose: bool = True,
-) -> tuple[nnx.Optimizer, list[float], list[float]]:
-    """Train a 4DVarNet model for multiple epochs.
-
-    Iterates over epochs and batches, logging train (and optional validation)
-    losses.  The ``model`` is updated in-place.
-
-    Args:
-        model: Flax NNX module (already initialised).
-        train_batches: List of training batches.
-        lr: Learning rate for the Adam optimiser.
-        n_epochs: Number of training epochs.
-        val_batches: Optional list of validation batches.
-        verbose: Whether to print per-epoch losses.
-
-    Returns:
-        Tuple of (optimizer, train loss history, val loss history).
-    """
-    optimizer = nnx.Optimizer(model, optax.adam(lr), wrt=nnx.Param)
-
-    train_losses: list[float] = []
-    val_losses: list[float] = []
-
-    for epoch in range(n_epochs):
-        epoch_train_losses = []
-        for batch in train_batches:
-            loss = train_step(model, optimizer, batch)
-            epoch_train_losses.append(float(loss))
-
-        mean_train = float(jnp.mean(jnp.array(epoch_train_losses)))
-        train_losses.append(mean_train)
-
-        mean_val = float("nan")
-        if val_batches is not None:
-            epoch_val_losses = [float(eval_step(model, b)) for b in val_batches]
-            mean_val = float(jnp.mean(jnp.array(epoch_val_losses)))
-        val_losses.append(mean_val)
-
-        if verbose:
-            print(
-                f"Epoch {epoch + 1}/{n_epochs} — "
-                f"train loss: {mean_train:.6f}"
-                + (f"  val loss: {mean_val:.6f}" if val_batches else "")
-            )
-
-    return optimizer, train_losses, val_losses
+    target = batch.target
+    if target is None:
+        raise ValueError("eval_step requires batch.target to be set.")
+    return reconstruction_loss(pred, target)

--- a/src/vardax/adjoints.py
+++ b/src/vardax/adjoints.py
@@ -1,0 +1,19 @@
+"""Public ``vardax.adjoints`` API surface.
+
+Re-exports from ``vardax._src.adjoints``. See that module's docstring
+for the design rationale (Decision D15).
+"""
+
+from vardax._src.adjoints import (
+    AbstractAdjoint,
+    ImplicitAdjoint,
+    OneStepAdjoint,
+    RecursiveCheckpointAdjoint,
+)
+
+__all__ = [
+    "AbstractAdjoint",
+    "ImplicitAdjoint",
+    "OneStepAdjoint",
+    "RecursiveCheckpointAdjoint",
+]

--- a/tests/test_grad_mod.py
+++ b/tests/test_grad_mod.py
@@ -1,6 +1,5 @@
 """Tests for vardax._src.grad_mod."""
 
-# (removed: flax dropped in equinox migration)
 import jax.numpy as jnp
 
 from vardax import ConvLSTMGradMod1D, ConvLSTMGradMod2D, LSTMState1D, LSTMState2D

--- a/tests/test_grad_mod.py
+++ b/tests/test_grad_mod.py
@@ -1,6 +1,6 @@
 """Tests for vardax._src.grad_mod."""
 
-from flax import nnx
+# (removed: flax dropped in equinox migration)
 import jax.numpy as jnp
 
 from vardax import ConvLSTMGradMod1D, ConvLSTMGradMod2D, LSTMState1D, LSTMState2D
@@ -10,9 +10,7 @@ class TestConvLSTMGradMod1D:
     def test_output_shapes(self, rng, batch_1d):
         B, T, N = batch_1d.input.shape
         hidden_dim = 16
-        model = ConvLSTMGradMod1D(
-            state_channels=T, hidden_dim=hidden_dim, rngs=nnx.Rngs(rng)
-        )
+        model = ConvLSTMGradMod1D(state_channels=T, hidden_dim=hidden_dim, key=rng)
         lstm = LSTMState1D.zeros(B, hidden_dim, N)
         update, new_lstm = model(batch_1d.input, batch_1d.input, lstm)
         assert update.shape == batch_1d.input.shape
@@ -22,9 +20,7 @@ class TestConvLSTMGradMod1D:
     def test_lstm_state_changes(self, rng, batch_1d):
         B, T, N = batch_1d.input.shape
         hidden_dim = 16
-        model = ConvLSTMGradMod1D(
-            state_channels=T, hidden_dim=hidden_dim, rngs=nnx.Rngs(rng)
-        )
+        model = ConvLSTMGradMod1D(state_channels=T, hidden_dim=hidden_dim, key=rng)
         lstm = LSTMState1D.zeros(B, hidden_dim, N)
         _, new_lstm = model(batch_1d.input, batch_1d.input, lstm)
         # Hidden state should have changed from zero
@@ -35,9 +31,7 @@ class TestConvLSTMGradMod2D:
     def test_output_shapes(self, rng, batch_2d):
         B, T, H, W = batch_2d.input.shape
         hidden_dim = 8
-        model = ConvLSTMGradMod2D(
-            state_channels=T, hidden_dim=hidden_dim, rngs=nnx.Rngs(rng)
-        )
+        model = ConvLSTMGradMod2D(state_channels=T, hidden_dim=hidden_dim, key=rng)
         lstm = LSTMState2D.zeros(B, hidden_dim, H, W)
         update, new_lstm = model(batch_2d.input, batch_2d.input, lstm)
         assert update.shape == batch_2d.input.shape

--- a/tests/test_linear_gaussian_agreement.py
+++ b/tests/test_linear_gaussian_agreement.py
@@ -28,6 +28,8 @@ import pytest
 
 from vardax import (
     Batch1D,
+    IncrementalConfig,
+    IncrementalFourDVar,
     MaskedIdentity,
     OptimalInterpolation,
     StrongFourDVar,
@@ -145,6 +147,27 @@ class TestLinearGaussianAgreement:
         oi_out = oi(s["batch"])[:, 0, :]
         strong_out = strong(s["batch"])
         assert jnp.allclose(oi_out, strong_out, atol=1e-3)
+
+    def test_incremental_4dvar_agrees_with_oi_in_3d_limit(self, linear_gaussian_setup):
+        """T_plus_1 = 1 ⇒ IncrementalFourDVar with IdentityForward = 3DVar."""
+        s = linear_gaussian_setup
+        oi = OptimalInterpolation(
+            obs_op=MaskedIdentity(),
+            prior_mean=s["prior_mean_with_time"],
+            prior_cov_op=s["B_op_with_time"],
+            obs_cov_op=s["R_op_with_time"],
+        )
+        inc = IncrementalFourDVar(
+            forward=IdentityForward(),
+            obs_op=MaskedIdentity(),
+            prior_mean=s["prior_mean_state"],
+            prior_cov_op=s["B_op_state"],
+            obs_cov_op=s["R_op_state"],
+            config=IncrementalConfig(n_outer=3, n_inner=30),
+        )
+        oi_out = oi(s["batch"])[:, 0, :]
+        inc_out = inc(s["batch"])
+        assert jnp.allclose(oi_out, inc_out, atol=1e-2)
 
     def test_weak_4dvar_x0_agrees_with_oi_in_3d_limit(self, linear_gaussian_setup):
         """T_plus_1 = 1 ⇒ WeakFourDVar has no η; reduces to 3DVar on x_0."""

--- a/tests/test_linear_gaussian_agreement.py
+++ b/tests/test_linear_gaussian_agreement.py
@@ -1,0 +1,223 @@
+"""The Decision D14 invariant — all DA methods agree in the linear-Gaussian limit.
+
+When :math:`H` is linear and :math:`B, R` are Gaussian, every analysis
+method must converge to the same posterior mean as
+``OptimalInterpolation`` (the closed-form BLUE). This is the canonical
+correctness gate: if a method disagrees with OI in this limit, the
+implementation is wrong.
+
+This module exercises the gate across:
+
+- ``OptimalInterpolation`` (the oracle)
+- ``ThreeDVar`` (iterative, single time)
+- ``StrongFourDVar`` (with an identity forward model so T_plus_1=1
+  reduces to the 3D case)
+- ``WeakFourDVar`` (same, with model error trivially zero at T=0)
+
+``FourDVarNet`` is not included here — its learned components must
+be initialised + trained to match, which isn't a unit test concern.
+"""
+
+from __future__ import annotations
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+import lineax as lx
+import pytest
+
+from vardax import (
+    Batch1D,
+    MaskedIdentity,
+    OptimalInterpolation,
+    StrongFourDVar,
+    ThreeDVar,
+    WeakFourDVar,
+)
+
+
+class IdentityForward(eqx.Module):
+    """Trivial dynamics: ``M_t(x) = x``. Makes 4DVar reduce to 3DVar."""
+
+    @property
+    def dt(self) -> float:
+        return 1.0
+
+    @property
+    def state_signature(self):
+        return None
+
+    def step(self, state, dt):
+        return state
+
+
+@pytest.fixture
+def linear_gaussian_setup():
+    """Identity B, R, MaskedIdentity H, batch with all observations valid."""
+    rng = jax.random.PRNGKey(42)
+    N, B = 4, 2
+
+    prior_mean_state = jnp.zeros(N)
+    prior_mean_with_time = prior_mean_state[None, :]  # shape (1, N)
+
+    B_op_state = lx.IdentityLinearOperator(jax.ShapeDtypeStruct((N,), jnp.float32))
+    R_op_state = lx.IdentityLinearOperator(jax.ShapeDtypeStruct((N,), jnp.float32))
+    B_op_with_time = lx.IdentityLinearOperator(
+        jax.ShapeDtypeStruct((1, N), jnp.float32)
+    )
+    R_op_with_time = lx.IdentityLinearOperator(
+        jax.ShapeDtypeStruct((1, N), jnp.float32)
+    )
+
+    batch = Batch1D(
+        input=jax.random.normal(rng, (B, 1, N)),
+        mask=jnp.ones((B, 1, N)),
+        target=None,
+    )
+
+    return {
+        "rng": rng,
+        "N": N,
+        "B": B,
+        "prior_mean_state": prior_mean_state,
+        "prior_mean_with_time": prior_mean_with_time,
+        "B_op_state": B_op_state,
+        "R_op_state": R_op_state,
+        "B_op_with_time": B_op_with_time,
+        "R_op_with_time": R_op_with_time,
+        "batch": batch,
+    }
+
+
+def _analytical_blue(batch: Batch1D) -> jax.Array:
+    """For ``B = R = I``, ``H = identity``, fully observed: ``x* = y / 2``."""
+    return batch.input[:, 0, :] / 2.0
+
+
+class TestLinearGaussianAgreement:
+    """All methods must agree in the linear-Gaussian limit (D14)."""
+
+    def test_oi_matches_analytical(self, linear_gaussian_setup):
+        s = linear_gaussian_setup
+        oi = OptimalInterpolation(
+            obs_op=MaskedIdentity(),
+            prior_mean=s["prior_mean_with_time"],
+            prior_cov_op=s["B_op_with_time"],
+            obs_cov_op=s["R_op_with_time"],
+        )
+        out = oi(s["batch"])
+        # OI returns shape (B, T, N); collapse the T=1 axis
+        assert jnp.allclose(out[:, 0, :], _analytical_blue(s["batch"]), atol=1e-4)
+
+    def test_3dvar_agrees_with_oi(self, linear_gaussian_setup):
+        s = linear_gaussian_setup
+        oi = OptimalInterpolation(
+            obs_op=MaskedIdentity(),
+            prior_mean=s["prior_mean_with_time"],
+            prior_cov_op=s["B_op_with_time"],
+            obs_cov_op=s["R_op_with_time"],
+        )
+        three = ThreeDVar(
+            obs_op=MaskedIdentity(),
+            prior_mean=s["prior_mean_with_time"],
+            prior_cov_op=s["B_op_with_time"],
+            obs_cov_op=s["R_op_with_time"],
+        )
+        assert jnp.allclose(oi(s["batch"]), three(s["batch"]), atol=1e-3)
+
+    def test_strong_4dvar_agrees_with_oi_in_3d_limit(self, linear_gaussian_setup):
+        """T_plus_1 = 1 ⇒ StrongFourDVar with IdentityForward = 3DVar."""
+        s = linear_gaussian_setup
+        oi = OptimalInterpolation(
+            obs_op=MaskedIdentity(),
+            prior_mean=s["prior_mean_with_time"],
+            prior_cov_op=s["B_op_with_time"],
+            obs_cov_op=s["R_op_with_time"],
+        )
+        strong = StrongFourDVar(
+            forward=IdentityForward(),
+            obs_op=MaskedIdentity(),
+            prior_mean=s["prior_mean_state"],
+            prior_cov_op=s["B_op_state"],
+            obs_cov_op=s["R_op_state"],
+        )
+        # OI shape (B, T=1, N) → squeeze; strong shape (B, N)
+        oi_out = oi(s["batch"])[:, 0, :]
+        strong_out = strong(s["batch"])
+        assert jnp.allclose(oi_out, strong_out, atol=1e-3)
+
+    def test_weak_4dvar_x0_agrees_with_oi_in_3d_limit(self, linear_gaussian_setup):
+        """T_plus_1 = 1 ⇒ WeakFourDVar has no η; reduces to 3DVar on x_0."""
+        s = linear_gaussian_setup
+        oi = OptimalInterpolation(
+            obs_op=MaskedIdentity(),
+            prior_mean=s["prior_mean_with_time"],
+            prior_cov_op=s["B_op_with_time"],
+            obs_cov_op=s["R_op_with_time"],
+        )
+        weak = WeakFourDVar(
+            forward=IdentityForward(),
+            obs_op=MaskedIdentity(),
+            prior_mean=s["prior_mean_state"],
+            prior_cov_op=s["B_op_state"],
+            obs_cov_op=s["R_op_state"],
+            model_err_cov_op=s["B_op_state"],  # ignored when T_plus_1=1
+        )
+        oi_out = oi(s["batch"])[:, 0, :]
+        x0_star, _ = weak(s["batch"])
+        assert jnp.allclose(oi_out, x0_star, atol=1e-3)
+
+
+class TestAnalysisStepConformance:
+    """Every classical method exposes ``.as_analysis_step()`` returning an AnalysisStep."""
+
+    def test_oi(self, linear_gaussian_setup):
+        s = linear_gaussian_setup
+        from vardax import AnalysisStep
+
+        oi = OptimalInterpolation(
+            obs_op=MaskedIdentity(),
+            prior_mean=s["prior_mean_with_time"],
+            prior_cov_op=s["B_op_with_time"],
+            obs_cov_op=s["R_op_with_time"],
+        )
+        assert isinstance(oi.as_analysis_step(), AnalysisStep)
+
+    def test_three_dvar(self, linear_gaussian_setup):
+        s = linear_gaussian_setup
+        from vardax import AnalysisStep
+
+        three = ThreeDVar(
+            obs_op=MaskedIdentity(),
+            prior_mean=s["prior_mean_with_time"],
+            prior_cov_op=s["B_op_with_time"],
+            obs_cov_op=s["R_op_with_time"],
+        )
+        assert isinstance(three.as_analysis_step(), AnalysisStep)
+
+    def test_strong_4dvar(self, linear_gaussian_setup):
+        s = linear_gaussian_setup
+        from vardax import AnalysisStep
+
+        strong = StrongFourDVar(
+            forward=IdentityForward(),
+            obs_op=MaskedIdentity(),
+            prior_mean=s["prior_mean_state"],
+            prior_cov_op=s["B_op_state"],
+            obs_cov_op=s["R_op_state"],
+        )
+        assert isinstance(strong.as_analysis_step(), AnalysisStep)
+
+    def test_weak_4dvar(self, linear_gaussian_setup):
+        s = linear_gaussian_setup
+        from vardax import AnalysisStep
+
+        weak = WeakFourDVar(
+            forward=IdentityForward(),
+            obs_op=MaskedIdentity(),
+            prior_mean=s["prior_mean_state"],
+            prior_cov_op=s["B_op_state"],
+            obs_cov_op=s["R_op_state"],
+            model_err_cov_op=s["B_op_state"],
+        )
+        assert isinstance(weak.as_analysis_step(), AnalysisStep)

--- a/tests/test_masked_residual_regression.py
+++ b/tests/test_masked_residual_regression.py
@@ -1,0 +1,182 @@
+"""Regression tests for the symmetric-masking bug fix (PR #41 review).
+
+For obs_ops that don't accept a ``mask`` kwarg (e.g. ``LinearObs``), the
+v0.2-dev classical methods originally formed residuals as
+``mask * y - obs_op(x)``, which left ``obs_op(x)`` unmasked at missing
+entries. That pulled the analysis toward zero in gaps. The fix is to
+mask both sides:
+
+    residual = mask * (y - obs_op(x))
+
+This module exercises that fix across ``ThreeDVar``, ``StrongFourDVar``,
+``WeakFourDVar``, and ``IncrementalFourDVar`` by checking that
+**partially-masked** problems with a **non-mask-aware** obs operator
+recover the analytical BLUE answer (which itself is mask-aware).
+
+The same masking is required inside ``OptimalInterpolation``'s
+``linearize()`` call — verified by exercising the OI path with a
+gap-mask and comparing against a hand-written BLUE.
+"""
+
+from __future__ import annotations
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+import lineax as lx
+import pytest
+
+from vardax import (
+    Batch1D,
+    IncrementalConfig,
+    IncrementalFourDVar,
+    LinearObs,
+    OptimalInterpolation,
+    StrongFourDVar,
+    ThreeDVar,
+    WeakFourDVar,
+)
+
+
+class IdentityForward(eqx.Module):
+    @property
+    def dt(self) -> float:
+        return 1.0
+
+    @property
+    def state_signature(self):
+        return None
+
+    def step(self, state, dt):
+        return state
+
+
+@pytest.fixture
+def masked_linear_gaussian():
+    """Linear-Gaussian setup with a gap mask.
+
+    obs_op is ``LinearObs(H_mat=I)`` (not mask-aware). Mask is
+    ``[1, 0, 1, 0]`` along the spatial axis so the analysis should
+    only update the *observed* entries.
+    """
+    rng = jax.random.PRNGKey(7)
+    N = 4
+    B = 1
+    # mask: 1, 0, 1, 0 (alternating gap pattern)
+    mask = jnp.array([[1.0, 0.0, 1.0, 0.0]])  # shape (T=1, N=4)
+    mask_batched = mask[None]  # (B=1, T=1, N=4)
+
+    y_truth = jax.random.normal(rng, (B, 1, N))
+    input_batched = y_truth * mask_batched
+
+    prior_mean_with_time = jnp.zeros((1, N))
+    prior_mean_state = jnp.zeros(N)
+
+    B_op_with_time = lx.IdentityLinearOperator(
+        jax.ShapeDtypeStruct((1, N), jnp.float32)
+    )
+    R_op_with_time = lx.IdentityLinearOperator(
+        jax.ShapeDtypeStruct((1, N), jnp.float32)
+    )
+    B_op_state = lx.IdentityLinearOperator(jax.ShapeDtypeStruct((N,), jnp.float32))
+    R_op_state = lx.IdentityLinearOperator(jax.ShapeDtypeStruct((N,), jnp.float32))
+
+    return {
+        "rng": rng,
+        "N": N,
+        "B": B,
+        "mask": mask_batched,
+        "input": input_batched,
+        "prior_mean_with_time": prior_mean_with_time,
+        "prior_mean_state": prior_mean_state,
+        "B_op_with_time": B_op_with_time,
+        "R_op_with_time": R_op_with_time,
+        "B_op_state": B_op_state,
+        "R_op_state": R_op_state,
+        # The analytical answer: observed entries → y/2, gaps → 0.
+        "expected": (input_batched / 2.0)[:, 0, :],
+    }
+
+
+def _identity_linear_obs_state(N: int) -> LinearObs:
+    """``LinearObs`` on a flat state ``(N,)`` — used by 4DVar variants."""
+    return LinearObs(
+        H_mat=lx.IdentityLinearOperator(jax.ShapeDtypeStruct((N,), jnp.float32))
+    )
+
+
+def _identity_linear_obs_with_time(N: int) -> LinearObs:
+    """``LinearObs`` on a ``(T=1, N)`` shape — used by OI / ThreeDVar."""
+    return LinearObs(
+        H_mat=lx.IdentityLinearOperator(jax.ShapeDtypeStruct((1, N), jnp.float32))
+    )
+
+
+class TestMaskedResidualRegression:
+    """Each classical method must recover ``y/2`` at observed entries
+    and stay at ``0`` at gaps (the analytical BLUE with B=R=I)."""
+
+    def test_oi_with_non_mask_aware_obs(self, masked_linear_gaussian):
+        s = masked_linear_gaussian
+        batch = Batch1D(input=s["input"], mask=s["mask"], target=None)
+        oi = OptimalInterpolation(
+            obs_op=_identity_linear_obs_with_time(s["N"]),
+            prior_mean=s["prior_mean_with_time"],
+            prior_cov_op=s["B_op_with_time"],
+            obs_cov_op=s["R_op_with_time"],
+        )
+        out = oi(batch)
+        assert jnp.allclose(out[:, 0, :], s["expected"], atol=1e-3)
+
+    def test_threedvar_with_non_mask_aware_obs(self, masked_linear_gaussian):
+        s = masked_linear_gaussian
+        batch = Batch1D(input=s["input"], mask=s["mask"], target=None)
+        three = ThreeDVar(
+            obs_op=_identity_linear_obs_with_time(s["N"]),
+            prior_mean=s["prior_mean_with_time"],
+            prior_cov_op=s["B_op_with_time"],
+            obs_cov_op=s["R_op_with_time"],
+        )
+        out = three(batch)
+        assert jnp.allclose(out[:, 0, :], s["expected"], atol=1e-2)
+
+    def test_strong_4dvar_with_non_mask_aware_obs(self, masked_linear_gaussian):
+        s = masked_linear_gaussian
+        batch = Batch1D(input=s["input"], mask=s["mask"], target=None)
+        strong = StrongFourDVar(
+            forward=IdentityForward(),
+            obs_op=_identity_linear_obs_state(s["N"]),
+            prior_mean=s["prior_mean_state"],
+            prior_cov_op=s["B_op_state"],
+            obs_cov_op=s["R_op_state"],
+        )
+        out = strong(batch)
+        assert jnp.allclose(out, s["expected"], atol=1e-2)
+
+    def test_incremental_4dvar_with_non_mask_aware_obs(self, masked_linear_gaussian):
+        s = masked_linear_gaussian
+        batch = Batch1D(input=s["input"], mask=s["mask"], target=None)
+        inc = IncrementalFourDVar(
+            forward=IdentityForward(),
+            obs_op=_identity_linear_obs_state(s["N"]),
+            prior_mean=s["prior_mean_state"],
+            prior_cov_op=s["B_op_state"],
+            obs_cov_op=s["R_op_state"],
+            config=IncrementalConfig(n_outer=4, n_inner=30),
+        )
+        out = inc(batch)
+        assert jnp.allclose(out, s["expected"], atol=1e-2)
+
+    def test_weak_4dvar_with_non_mask_aware_obs(self, masked_linear_gaussian):
+        s = masked_linear_gaussian
+        batch = Batch1D(input=s["input"], mask=s["mask"], target=None)
+        weak = WeakFourDVar(
+            forward=IdentityForward(),
+            obs_op=_identity_linear_obs_state(s["N"]),
+            prior_mean=s["prior_mean_state"],
+            prior_cov_op=s["B_op_state"],
+            obs_cov_op=s["R_op_state"],
+            model_err_cov_op=s["B_op_state"],
+        )
+        x0_star, _ = weak(batch)
+        assert jnp.allclose(x0_star, s["expected"], atol=1e-2)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -2,9 +2,11 @@
 
 import jax
 import jax.numpy as jnp
+import optimistix as optx
 import pytest
 
 from vardax import FourDVarNet1D, FourDVarNet2D
+from vardax.adjoints import OneStepAdjoint
 
 
 class TestFourDVarNet1D:
@@ -20,29 +22,6 @@ class TestFourDVarNet1D:
         )
         out = model(batch_1d)
         assert out.shape == (B, T, N)
-
-    @pytest.mark.slow
-    def test_output_changes_with_different_masks(self, rng, batch_1d):
-        from vardax import Batch1D
-
-        _, T, N = batch_1d.input.shape
-        model = FourDVarNet1D(
-            state_dim=N,
-            n_time=T,
-            latent_dim=8,
-            hidden_dim=16,
-            n_solver_steps=2,
-            key=rng,
-        )
-        out1 = model(batch_1d)
-        # All-zero mask
-        batch_no_obs = Batch1D(
-            input=batch_1d.input,
-            mask=jnp.zeros_like(batch_1d.mask),
-            target=batch_1d.target,
-        )
-        out2 = model(batch_no_obs)
-        assert not jnp.allclose(out1, out2)
 
 
 class TestFourDVarNet2D:
@@ -60,7 +39,7 @@ class TestFourDVarNet2D:
         out = model(batch_2d)
         assert out.shape == (B, T, H, W)
 
-    def test_implicit_grad_mode_raises(self, rng, batch_2d):
+    def test_implicit_adjoint_raises(self, rng, batch_2d):
         _B, T, H, W = batch_2d.input.shape
         model = FourDVarNet2D(
             n_time=T,
@@ -69,16 +48,26 @@ class TestFourDVarNet2D:
             latent_dim=8,
             hidden_dim=8,
             n_solver_steps=2,
-            grad_mode="implicit",
+            solver_adjoint=optx.ImplicitAdjoint(),
             key=rng,
         )
         with pytest.raises(NotImplementedError):
             model(batch_2d)
 
 
-class TestFourDVarNet1DGradMode:
-    @pytest.mark.parametrize("grad_mode", ["unrolled", "one_step", "implicit"])
-    def test_output_shape(self, rng, batch_1d, grad_mode):
+class TestFourDVarNet1DAdjointDispatch:
+    """Test that ``solver_adjoint`` selects the correct inner path."""
+
+    @pytest.mark.parametrize(
+        "adjoint",
+        [
+            optx.RecursiveCheckpointAdjoint(),
+            OneStepAdjoint(),
+            optx.ImplicitAdjoint(),
+        ],
+        ids=["recursive_checkpoint", "one_step", "implicit"],
+    )
+    def test_output_shape(self, rng, batch_1d, adjoint):
         B, T, N = batch_1d.input.shape
         model = FourDVarNet1D(
             state_dim=N,
@@ -86,25 +75,11 @@ class TestFourDVarNet1DGradMode:
             latent_dim=8,
             hidden_dim=16,
             n_solver_steps=3,
-            grad_mode=grad_mode,
+            solver_adjoint=adjoint,
             key=rng,
         )
         out = model(batch_1d)
         assert out.shape == (B, T, N)
-
-    def test_invalid_grad_mode_raises(self, rng, batch_1d):
-        _B, T, N = batch_1d.input.shape
-        model = FourDVarNet1D(
-            state_dim=N,
-            n_time=T,
-            latent_dim=8,
-            hidden_dim=16,
-            n_solver_steps=3,
-            grad_mode="invalid",  # type: ignore[arg-type]
-            key=rng,
-        )
-        with pytest.raises(ValueError, match="Unknown grad_mode"):
-            model(batch_1d)
 
     def test_one_step_gradients_are_finite(self, rng, batch_1d):
         import equinox as eqx
@@ -116,7 +91,7 @@ class TestFourDVarNet1DGradMode:
             latent_dim=8,
             hidden_dim=16,
             n_solver_steps=3,
-            grad_mode="one_step",
+            solver_adjoint=OneStepAdjoint(),
             key=rng,
         )
 
@@ -128,3 +103,16 @@ class TestFourDVarNet1DGradMode:
         assert jnp.isfinite(loss)
         leaves = jax.tree_util.tree_leaves(eqx.filter(grads, eqx.is_array))
         assert all(jnp.all(jnp.isfinite(g)) for g in leaves)
+
+    def test_default_is_recursive_checkpoint(self, rng, batch_1d):
+        """No ``solver_adjoint`` arg → default to ``RecursiveCheckpointAdjoint``."""
+        _B, T, N = batch_1d.input.shape
+        model = FourDVarNet1D(
+            state_dim=N,
+            n_time=T,
+            latent_dim=8,
+            hidden_dim=16,
+            n_solver_steps=3,
+            key=rng,
+        )
+        assert isinstance(model.solver_adjoint, optx.RecursiveCheckpointAdjoint)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,6 +1,5 @@
 """Tests for vardax._src.model."""
 
-# (removed: flax dropped in equinox migration)
 import jax
 import jax.numpy as jnp
 import pytest

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,6 +1,6 @@
 """Tests for vardax._src.model."""
 
-from flax import nnx
+# (removed: flax dropped in equinox migration)
 import jax
 import jax.numpy as jnp
 import pytest
@@ -17,7 +17,7 @@ class TestFourDVarNet1D:
             latent_dim=8,
             hidden_dim=16,
             n_solver_steps=2,
-            rngs=nnx.Rngs(rng),
+            key=rng,
         )
         out = model(batch_1d)
         assert out.shape == (B, T, N)
@@ -33,7 +33,7 @@ class TestFourDVarNet1D:
             latent_dim=8,
             hidden_dim=16,
             n_solver_steps=2,
-            rngs=nnx.Rngs(rng),
+            key=rng,
         )
         out1 = model(batch_1d)
         # All-zero mask
@@ -56,7 +56,7 @@ class TestFourDVarNet2D:
             latent_dim=8,
             hidden_dim=8,
             n_solver_steps=2,
-            rngs=nnx.Rngs(rng),
+            key=rng,
         )
         out = model(batch_2d)
         assert out.shape == (B, T, H, W)
@@ -71,7 +71,7 @@ class TestFourDVarNet2D:
             hidden_dim=8,
             n_solver_steps=2,
             grad_mode="implicit",
-            rngs=nnx.Rngs(rng),
+            key=rng,
         )
         with pytest.raises(NotImplementedError):
             model(batch_2d)
@@ -88,7 +88,7 @@ class TestFourDVarNet1DGradMode:
             hidden_dim=16,
             n_solver_steps=3,
             grad_mode=grad_mode,
-            rngs=nnx.Rngs(rng),
+            key=rng,
         )
         out = model(batch_1d)
         assert out.shape == (B, T, N)
@@ -102,13 +102,13 @@ class TestFourDVarNet1DGradMode:
             hidden_dim=16,
             n_solver_steps=3,
             grad_mode="invalid",  # type: ignore[arg-type]
-            rngs=nnx.Rngs(rng),
+            key=rng,
         )
         with pytest.raises(ValueError, match="Unknown grad_mode"):
             model(batch_1d)
 
     def test_one_step_gradients_are_finite(self, rng, batch_1d):
-        import optax
+        import equinox as eqx
 
         _B, T, N = batch_1d.input.shape
         model = FourDVarNet1D(
@@ -118,15 +118,14 @@ class TestFourDVarNet1DGradMode:
             hidden_dim=16,
             n_solver_steps=3,
             grad_mode="one_step",
-            rngs=nnx.Rngs(rng),
+            key=rng,
         )
-        nnx.Optimizer(model, optax.adam(1e-3), wrt=nnx.Param)
 
         def loss_fn(model):
             x_hat = model(batch_1d)
             return jnp.mean((x_hat - batch_1d.target) ** 2)
 
-        loss, grads = nnx.value_and_grad(loss_fn)(model)
+        loss, grads = eqx.filter_value_and_grad(loss_fn)(model)
         assert jnp.isfinite(loss)
-        leaves = jax.tree_util.tree_leaves(nnx.state(grads))
+        leaves = jax.tree_util.tree_leaves(eqx.filter(grads, eqx.is_array))
         assert all(jnp.all(jnp.isfinite(g)) for g in leaves)

--- a/tests/test_obs_operators.py
+++ b/tests/test_obs_operators.py
@@ -1,0 +1,186 @@
+"""Tests for the Layer 1 observation operator family."""
+
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+import lineax as lx
+import pytest
+
+from vardax import (
+    AveragingKernel,
+    InstrumentRegistry,
+    InstrumentSpec,
+    LinearObs,
+    MaskedIdentity,
+    MultiInstrumentFusion,
+    ObservationOperator,
+)
+
+
+@pytest.fixture
+def rng():
+    return jax.random.PRNGKey(0)
+
+
+# ---------------------------------------------------------------------------
+# Protocol conformance
+# ---------------------------------------------------------------------------
+
+
+class TestObservationOperatorProtocol:
+    def test_masked_identity(self):
+        assert isinstance(MaskedIdentity(), ObservationOperator)
+
+    def test_linear_obs(self, rng):
+        H = lx.MatrixLinearOperator(jax.random.normal(rng, (3, 4)))
+        assert isinstance(LinearObs(H_mat=H), ObservationOperator)
+
+    def test_averaging_kernel(self, rng):
+        n = 4
+        A = lx.MatrixLinearOperator(jax.random.normal(rng, (n, n)))
+        ak = AveragingKernel(A=A, x_a=jnp.zeros(n), h=jnp.ones(n))
+        assert isinstance(ak, ObservationOperator)
+
+    def test_multi_instrument_fusion_via_flatten_adapter(self, rng):
+        n = 4
+        A = lx.MatrixLinearOperator(jnp.eye(n))
+        spec = InstrumentSpec(
+            obs_op=AveragingKernel(A=A, x_a=jnp.zeros(n), h=jnp.ones(n)),
+            mask=jnp.ones(n),
+            R_op=lx.DiagonalLinearOperator(jnp.ones(n)),
+            instrument_id="tropomi",
+        )
+        fusion = MultiInstrumentFusion(
+            registry=InstrumentRegistry(entries={"tropomi": spec}),
+        )
+        # The fusion itself returns a dict, not Array — for strict
+        # ObservationOperator conformance, use .to_observation_operator()
+        flattened = fusion.to_observation_operator()
+        assert isinstance(flattened, ObservationOperator)
+
+
+# ---------------------------------------------------------------------------
+# MaskedIdentity
+# ---------------------------------------------------------------------------
+
+
+class TestMaskedIdentity:
+    def test_passthrough_without_mask(self, rng):
+        op = MaskedIdentity()
+        x = jax.random.normal(rng, (3, 4))
+        assert jnp.allclose(op(x), x)
+
+    def test_applies_mask(self, rng):
+        op = MaskedIdentity()
+        x = jnp.ones((3, 4))
+        mask = jnp.array([[1.0, 0.0, 1.0, 0.0]] * 3)
+        out = op(x, mask=mask)
+        assert jnp.allclose(out, mask)
+
+    def test_linearize_returns_operator(self, rng):
+        op = MaskedIdentity()
+        x = jax.random.normal(rng, (4,))
+        H = op.linearize(x)
+        assert isinstance(H, lx.AbstractLinearOperator)
+
+
+# ---------------------------------------------------------------------------
+# LinearObs
+# ---------------------------------------------------------------------------
+
+
+class TestLinearObs:
+    def test_applies_matrix(self, rng):
+        H_mat = jax.random.normal(rng, (3, 5))
+        op = LinearObs(H_mat=lx.MatrixLinearOperator(H_mat))
+        x = jax.random.normal(rng, (5,))
+        out = op(x)
+        assert jnp.allclose(out, H_mat @ x, atol=1e-5)
+
+    def test_linearize_is_self(self, rng):
+        H_mat = lx.MatrixLinearOperator(jax.random.normal(rng, (3, 5)))
+        op = LinearObs(H_mat=H_mat)
+        H = op.linearize(jnp.zeros(5))
+        # For a linear operator, the tangent linear is the operator itself.
+        assert H is H_mat
+
+
+# ---------------------------------------------------------------------------
+# AveragingKernel (Decision D9)
+# ---------------------------------------------------------------------------
+
+
+class TestAveragingKernel:
+    def test_with_full_weighting_recovers_A_x(self, rng):
+        n = 6
+        A_mat = jax.random.normal(rng, (n, n))
+        op = AveragingKernel(
+            A=lx.MatrixLinearOperator(A_mat),
+            x_a=jnp.zeros(n),
+            h=jnp.ones(n),  # full weight on the model state
+        )
+        x = jax.random.normal(rng, (n,))
+        # h = 1 ⇒ inner = x, output = A @ x
+        assert jnp.allclose(op(x), A_mat @ x, atol=1e-5)
+
+    def test_with_zero_weighting_returns_A_x_a(self, rng):
+        n = 6
+        A_mat = jax.random.normal(rng, (n, n))
+        x_a = jax.random.normal(rng, (n,))
+        op = AveragingKernel(
+            A=lx.MatrixLinearOperator(A_mat),
+            x_a=x_a,
+            h=jnp.zeros(n),  # all weight on the retrieval prior
+        )
+        x = jax.random.normal(rng, (n,))
+        # h = 0 ⇒ inner = x_a, output = A @ x_a, independent of x
+        assert jnp.allclose(op(x), A_mat @ x_a, atol=1e-5)
+
+    def test_linearize_adjoint_test(self, rng):
+        """Adjoint test: <H'u, v> == <u, H'^T v> for random u, v."""
+        n = 5
+        A_mat = jax.random.normal(rng, (n, n))
+        h = jax.random.uniform(rng, (n,))
+        op = AveragingKernel(
+            A=lx.MatrixLinearOperator(A_mat),
+            x_a=jnp.zeros(n),
+            h=h,
+        )
+        H = op.linearize(jnp.zeros(n))
+        k1, k2 = jax.random.split(rng)
+        u = jax.random.normal(k1, (n,))
+        v = jax.random.normal(k2, (n,))
+        forward_inner = jnp.dot(H.mv(u), v)
+        adjoint_inner = jnp.dot(u, H.transpose().mv(v))
+        assert jnp.isclose(forward_inner, adjoint_inner, atol=1e-4)
+
+
+# ---------------------------------------------------------------------------
+# MultiInstrumentFusion
+# ---------------------------------------------------------------------------
+
+
+class TestMultiInstrumentFusion:
+    def test_per_instrument_dict_output(self, rng):
+        n = 4
+        spec_a = InstrumentSpec(
+            obs_op=MaskedIdentity(),
+            mask=jnp.ones(n),
+            R_op=lx.DiagonalLinearOperator(jnp.ones(n)),
+            instrument_id="A",
+        )
+        spec_b = InstrumentSpec(
+            obs_op=LinearObs(H_mat=lx.MatrixLinearOperator(jnp.eye(n) * 2.0)),
+            mask=jnp.ones(n),
+            R_op=lx.DiagonalLinearOperator(jnp.ones(n)),
+            instrument_id="B",
+        )
+        fusion = MultiInstrumentFusion(
+            registry=InstrumentRegistry(entries={"A": spec_a, "B": spec_b}),
+        )
+        x = jax.random.normal(rng, (n,))
+        out = fusion(x)
+        assert set(out.keys()) == {"A", "B"}
+        assert jnp.allclose(out["A"], x, atol=1e-5)
+        assert jnp.allclose(out["B"], 2.0 * x, atol=1e-5)

--- a/tests/test_pipekit_protocols.py
+++ b/tests/test_pipekit_protocols.py
@@ -1,0 +1,96 @@
+"""Conformance suite for pipekit-cycle and vardax-specific protocols.
+
+Per Decision D8, vardax classes satisfy ``pipekit_cycle.{ForwardModel,
+ObservationOperator, AnalysisStep}`` directly (no parallel ``Abstract*``
+hierarchy). This module verifies that conformance by:
+
+1. Importing the runtime-checkable protocols.
+2. Building concrete instances of every Layer 1/2 class.
+3. Asserting ``isinstance(instance, Protocol)`` succeeds.
+
+When new Layer 2 analysis methods are added (OptimalInterpolation,
+ThreeDVar, StrongFourDVar, WeakFourDVar, IncrementalFourDVar,
+AmortizedPosterior in Phases 2 and 3), each one must also be added to
+``test_model_yields_analysis_step``.
+"""
+
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+import pytest
+
+from vardax import (
+    AnalysisStep,
+    BilinAEPrior1D,
+    ConvLSTMGradMod1D,
+    CostFunction,
+    FourDVarNet1D,
+    GradModulator,
+    Prior,
+)
+
+
+@pytest.fixture
+def rng():
+    return jax.random.PRNGKey(0)
+
+
+class TestPriorProtocol:
+    def test_bilin_ae_prior_satisfies_prior(self, rng):
+        prior = BilinAEPrior1D(state_dim=4, latent_dim=2, n_time=3, key=rng)
+        assert isinstance(prior, Prior)
+
+    def test_callable_returns_array(self, rng):
+        prior = BilinAEPrior1D(state_dim=4, latent_dim=2, n_time=3, key=rng)
+        x = jnp.zeros((2, 3, 4))
+        out = prior(x)
+        assert out.shape == x.shape
+
+
+class TestGradModulatorProtocol:
+    def test_conv_lstm_satisfies_grad_modulator(self, rng):
+        grad_mod = ConvLSTMGradMod1D(state_channels=3, hidden_dim=4, key=rng)
+        assert isinstance(grad_mod, GradModulator)
+
+
+class TestAnalysisStepProtocol:
+    """Every Layer 2 model must expose ``.as_analysis_step()``."""
+
+    def test_fourdvarnet1d_yields_analysis_step(self, rng):
+        model = FourDVarNet1D(
+            state_dim=4,
+            n_time=3,
+            latent_dim=2,
+            hidden_dim=4,
+            n_solver_steps=2,
+            key=rng,
+        )
+        step = model.as_analysis_step()
+        assert isinstance(step, AnalysisStep)
+
+    def test_analysis_step_callable(self, rng):
+        model = FourDVarNet1D(
+            state_dim=4,
+            n_time=3,
+            latent_dim=2,
+            hidden_dim=4,
+            n_solver_steps=2,
+            key=rng,
+        )
+        step = model.as_analysis_step()
+        # Forecast + obs with NaN-masked entries
+        forecast = jnp.zeros((2, 3, 4))
+        obs = forecast.at[:, 0, 0].set(jnp.nan)  # one missing pixel
+        analysis = step(forecast, obs, obs_op=None, obs_err_cov=None)
+        assert analysis.shape == forecast.shape
+
+
+class TestCostFunctionProtocol:
+    """``CostFunction`` is satisfied by any callable with the right signature."""
+
+    def test_lambda_satisfies(self):
+        def cost(x, batch):
+            return jnp.sum(x**2)
+
+        assert isinstance(cost, CostFunction)

--- a/tests/test_posterior.py
+++ b/tests/test_posterior.py
@@ -1,0 +1,140 @@
+"""Tests for the posterior-adapter family (Epic 5)."""
+
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+import lineax as lx
+import pytest
+
+from vardax import (
+    Batch1D,
+    EnsembleCovariance,
+    GaussianMarkLikelihood,
+    GaussNewtonHessian,
+    LaplaceCovariance,
+    MaskedIdentity,
+    OptimalInterpolation,
+    Posterior,
+)
+
+
+@pytest.fixture
+def linear_gaussian_oi():
+    """Standard OI setup for testing posteriors."""
+    T, N, B = 1, 4, 2
+    prior_mean = jnp.zeros((T, N))
+    B_op = lx.IdentityLinearOperator(jax.ShapeDtypeStruct((T, N), jnp.float32))
+    R_op = lx.IdentityLinearOperator(jax.ShapeDtypeStruct((T, N), jnp.float32))
+    oi = OptimalInterpolation(
+        obs_op=MaskedIdentity(),
+        prior_mean=prior_mean,
+        prior_cov_op=B_op,
+        obs_cov_op=R_op,
+    )
+    batch = Batch1D(
+        input=jax.random.normal(jax.random.PRNGKey(0), (B, T, N)),
+        mask=jnp.ones((B, T, N)),
+        target=None,
+    )
+    return {"oi": oi, "batch": batch, "B_op": B_op, "R_op": R_op}
+
+
+class TestPosteriorContainer:
+    def test_basic_construction(self):
+        post = Posterior(mean=jnp.zeros(4))
+        assert post.mean.shape == (4,)
+        assert post.cov is None
+        assert post.samples is None
+        assert post.provenance == {}
+
+    def test_with_provenance(self):
+        post = Posterior(
+            mean=jnp.zeros(4),
+            provenance={"forward_model_id": "test", "n_iter": 5},
+        )
+        assert post.provenance["forward_model_id"] == "test"
+
+
+class TestLaplaceCovariance:
+    def test_returns_posterior(self, linear_gaussian_oi):
+        s = linear_gaussian_oi
+        analysis = s["oi"](s["batch"])
+        laplace = LaplaceCovariance(prior_cov_op=s["B_op"], obs_cov_op=s["R_op"])
+        post = laplace(analysis[0], s["oi"].as_analysis_step(), s["batch"])
+        assert isinstance(post, Posterior)
+        assert post.cov is not None
+        assert post.provenance["adapter"] == "LaplaceCovariance"
+
+    def test_cov_matvec(self, linear_gaussian_oi):
+        """Covariance op should be mat-vec-able (without materialising)."""
+        s = linear_gaussian_oi
+        analysis = s["oi"](s["batch"])
+        laplace = LaplaceCovariance(prior_cov_op=s["B_op"], obs_cov_op=s["R_op"])
+        post = laplace(analysis[0], s["oi"].as_analysis_step(), s["batch"])
+        v = jnp.ones_like(post.mean)
+        # For B=R=I and fully-observed H=I: P* = (I + I)^{-1} = I/2
+        cov_v = post.cov.mv(v)
+        assert jnp.allclose(cov_v, v / 2, atol=1e-2)
+
+
+class TestGaussNewtonHessian:
+    def test_returns_posterior(self, linear_gaussian_oi):
+        s = linear_gaussian_oi
+        analysis = s["oi"](s["batch"])
+        gn = GaussNewtonHessian(prior_cov_op=s["B_op"], obs_cov_op=s["R_op"])
+        post = gn(analysis[0], s["oi"].as_analysis_step(), s["batch"])
+        assert isinstance(post, Posterior)
+        assert post.provenance["adapter"] == "GaussNewtonHessian"
+
+
+class TestEnsembleCovariance:
+    def test_sample_cov(self, linear_gaussian_oi):
+        s = linear_gaussian_oi
+        # Build an ensemble of 32 samples around the analysis mean
+        analysis = s["oi"](s["batch"])
+        rng = jax.random.PRNGKey(42)
+        perturbations = jax.random.normal(rng, (32, *analysis.shape[1:]))
+        ensemble = analysis[0] + perturbations  # (32, T, N)
+
+        ec = EnsembleCovariance(n_members=32)
+        post = ec(ensemble, s["oi"].as_analysis_step(), s["batch"])
+        assert isinstance(post, Posterior)
+        assert post.samples is not None
+        assert post.samples.shape == ensemble.shape
+        assert post.provenance["n_members"] == 32
+
+
+class TestGaussianMarkLikelihood:
+    def test_to_dict_keys(self, linear_gaussian_oi):
+        s = linear_gaussian_oi
+        analysis = s["oi"](s["batch"])
+        laplace = LaplaceCovariance(prior_cov_op=s["B_op"], obs_cov_op=s["R_op"])
+        post = laplace(analysis[0], s["oi"].as_analysis_step(), s["batch"])
+        mark = GaussianMarkLikelihood(
+            posterior=post,
+            event_metadata={"event_id": "test", "time": "2026-05-27"},
+        )
+        d = mark.to_dict()
+        assert set(d.keys()) == {
+            "mean",
+            "cov_diag",
+            "samples",
+            "provenance",
+            "event_metadata",
+        }
+        assert d["event_metadata"]["event_id"] == "test"
+
+    def test_serialises_to_json_compatible_types(self, linear_gaussian_oi):
+        """Result should be json.dumps-able."""
+        import json
+
+        s = linear_gaussian_oi
+        analysis = s["oi"](s["batch"])
+        laplace = LaplaceCovariance(prior_cov_op=s["B_op"], obs_cov_op=s["R_op"])
+        post = laplace(analysis[0], s["oi"].as_analysis_step(), s["batch"])
+        # Cov_diag may be None for lazy operators — strip it for the JSON test
+        mark = GaussianMarkLikelihood(posterior=Posterior(mean=post.mean))
+        d = mark.to_dict()
+        # Should serialise without error
+        json.dumps(d)

--- a/tests/test_priors.py
+++ b/tests/test_priors.py
@@ -1,6 +1,6 @@
 """Tests for vardax._src.priors."""
 
-from flax import nnx
+# (removed: flax dropped in equinox migration)
 import jax.numpy as jnp
 
 from vardax import (
@@ -16,12 +16,12 @@ from vardax import (
 
 class TestBilinAEPrior1D:
     def test_output_shape(self, rng, batch_1d):
-        model = BilinAEPrior1D(state_dim=16, latent_dim=8, n_time=5, rngs=nnx.Rngs(rng))
+        model = BilinAEPrior1D(state_dim=16, latent_dim=8, n_time=5, key=rng)
         out = model(batch_1d.input)
         assert out.shape == batch_1d.input.shape
 
     def test_encode_decode_shapes(self, rng, batch_1d):
-        model = BilinAEPrior1D(state_dim=16, latent_dim=8, n_time=5, rngs=nnx.Rngs(rng))
+        model = BilinAEPrior1D(state_dim=16, latent_dim=8, n_time=5, key=rng)
         z = model.encode(batch_1d.input)
         assert z.shape == (batch_1d.input.shape[0], 8)
         decoded = model.decode(z)
@@ -31,7 +31,7 @@ class TestBilinAEPrior1D:
 class TestMLPAEPrior1D:
     def test_output_shape(self, rng, batch_1d):
         model = MLPAEPrior1D(
-            state_dim=16, latent_dim=8, hidden_dim=32, n_time=5, rngs=nnx.Rngs(rng)
+            state_dim=16, latent_dim=8, hidden_dim=32, n_time=5, key=rng
         )
         out = model(batch_1d.input)
         assert out.shape == batch_1d.input.shape
@@ -40,9 +40,7 @@ class TestMLPAEPrior1D:
 class TestBilinAEPrior2D:
     def test_output_shape(self, rng, batch_2d):
         _, T, H, W = batch_2d.input.shape
-        model = BilinAEPrior2D(
-            latent_dim=16, n_time=T, height=H, width=W, rngs=nnx.Rngs(rng)
-        )
+        model = BilinAEPrior2D(latent_dim=16, n_time=T, height=H, width=W, key=rng)
         out = model(batch_2d.input)
         assert out.shape == batch_2d.input.shape
 
@@ -56,7 +54,7 @@ class TestBilinAEPrior2DMultivar:
             n_channels=C,
             height=H,
             width=W,
-            rngs=nnx.Rngs(rng),
+            key=rng,
         )
         out = model(batch_2d_multivar.input)
         assert out.shape == batch_2d_multivar.input.shape
@@ -64,7 +62,7 @@ class TestBilinAEPrior2DMultivar:
 
 class TestL63Prior:
     def test_output_shape(self, rng):
-        model = L63Prior(latent_dim=3, hidden_dim=16, state_dim=3, rngs=nnx.Rngs(rng))
+        model = L63Prior(latent_dim=3, hidden_dim=16, state_dim=3, key=rng)
         x = jnp.ones((4, 3))
         out = model(x)
         assert out.shape == (4, 3)
@@ -72,13 +70,13 @@ class TestL63Prior:
 
 class TestL96Prior:
     def test_output_shape(self, rng):
-        model = L96Prior(latent_dim=16, hidden_dim=64, state_dim=40, rngs=nnx.Rngs(rng))
+        model = L96Prior(latent_dim=16, hidden_dim=64, state_dim=40, key=rng)
         x = jnp.ones((4, 40))
         out = model(x)
         assert out.shape == (4, 40)
 
     def test_custom_state_size(self, rng):
-        model = L96Prior(latent_dim=8, hidden_dim=32, state_dim=20, rngs=nnx.Rngs(rng))
+        model = L96Prior(latent_dim=8, hidden_dim=32, state_dim=20, key=rng)
         x = jnp.ones((2, 20))
         out = model(x)
         assert out.shape == (2, 20)
@@ -86,17 +84,13 @@ class TestL96Prior:
 
 class TestConvAEPrior1D:
     def test_output_shape(self, rng):
-        model = ConvAEPrior1D(
-            latent_channels=8, kernel_size=3, n_time=5, rngs=nnx.Rngs(rng)
-        )
+        model = ConvAEPrior1D(latent_channels=8, kernel_size=3, n_time=5, key=rng)
         x = jnp.ones((2, 5, 40))
         out = model(x)
         assert out.shape == (2, 5, 40)
 
     def test_small_spatial_dim(self, rng):
-        model = ConvAEPrior1D(
-            latent_channels=4, kernel_size=3, n_time=3, rngs=nnx.Rngs(rng)
-        )
+        model = ConvAEPrior1D(latent_channels=4, kernel_size=3, n_time=3, key=rng)
         x = jnp.ones((2, 3, 10))
         out = model(x)
         assert out.shape == (2, 3, 10)

--- a/tests/test_priors.py
+++ b/tests/test_priors.py
@@ -1,6 +1,5 @@
 """Tests for vardax._src.priors."""
 
-# (removed: flax dropped in equinox migration)
 import jax.numpy as jnp
 
 from vardax import (

--- a/tests/test_solver.py
+++ b/tests/test_solver.py
@@ -1,6 +1,5 @@
 """Tests for vardax._src.solver."""
 
-# (removed: flax dropped in equinox migration)
 import jax
 import jax.numpy as jnp
 

--- a/tests/test_solver.py
+++ b/tests/test_solver.py
@@ -1,6 +1,6 @@
 """Tests for vardax._src.solver."""
 
-from flax import nnx
+# (removed: flax dropped in equinox migration)
 import jax
 import jax.numpy as jnp
 
@@ -43,10 +43,8 @@ class TestSolverStep1D:
         B, T, N = batch_1d.input.shape
         hidden_dim = 16
         k1, k2 = jax.random.split(rng)
-        prior = BilinAEPrior1D(state_dim=N, latent_dim=8, n_time=T, rngs=nnx.Rngs(k1))
-        grad_mod = ConvLSTMGradMod1D(
-            state_channels=T, hidden_dim=hidden_dim, rngs=nnx.Rngs(k2)
-        )
+        prior = BilinAEPrior1D(state_dim=N, latent_dim=8, n_time=T, key=k1)
+        grad_mod = ConvLSTMGradMod1D(state_channels=T, hidden_dim=hidden_dim, key=k2)
 
         x0 = batch_1d.input * batch_1d.mask
         lstm = LSTMState1D.zeros(B, hidden_dim, N)
@@ -61,10 +59,8 @@ class TestSolverStep1D:
         B, T, N = batch_1d.input.shape
         hidden_dim = 16
         k1, k2 = jax.random.split(rng)
-        prior = BilinAEPrior1D(state_dim=N, latent_dim=8, n_time=T, rngs=nnx.Rngs(k1))
-        grad_mod = ConvLSTMGradMod1D(
-            state_channels=T, hidden_dim=hidden_dim, rngs=nnx.Rngs(k2)
-        )
+        prior = BilinAEPrior1D(state_dim=N, latent_dim=8, n_time=T, key=k1)
+        grad_mod = ConvLSTMGradMod1D(state_channels=T, hidden_dim=hidden_dim, key=k2)
 
         x0 = batch_1d.input * batch_1d.mask
         lstm = LSTMState1D.zeros(B, hidden_dim, N)
@@ -96,7 +92,7 @@ class TestSolve4dvarnet1dFixedpoint:
         from vardax import BilinAEPrior1D
 
         B, T, N = batch_1d.input.shape
-        prior = BilinAEPrior1D(state_dim=N, latent_dim=4, n_time=T, rngs=nnx.Rngs(rng))
+        prior = BilinAEPrior1D(state_dim=N, latent_dim=4, n_time=T, key=rng)
 
         result = solve_4dvarnet_1d_fixedpoint(batch_1d, prior, n_fp_steps=5)
         assert result.shape == (B, T, N)
@@ -105,7 +101,7 @@ class TestSolve4dvarnet1dFixedpoint:
         from vardax import BilinAEPrior1D
 
         B, T, N = batch_1d.input.shape
-        prior = BilinAEPrior1D(state_dim=N, latent_dim=4, n_time=T, rngs=nnx.Rngs(rng))
+        prior = BilinAEPrior1D(state_dim=N, latent_dim=4, n_time=T, key=rng)
         x0 = batch_1d.input * batch_1d.mask
 
         result = solve_4dvarnet_1d_fixedpoint(batch_1d, prior, n_fp_steps=0)
@@ -120,8 +116,8 @@ class TestOneStepSolve4dvarnet1D:
 
         B, T, N = batch_1d.input.shape
         k1, k2 = jax.random.split(rng)
-        prior = BilinAEPrior1D(state_dim=N, latent_dim=4, n_time=T, rngs=nnx.Rngs(k1))
-        grad_mod = ConvLSTMGradMod1D(state_channels=T, hidden_dim=16, rngs=nnx.Rngs(k2))
+        prior = BilinAEPrior1D(state_dim=N, latent_dim=4, n_time=T, key=k1)
+        grad_mod = ConvLSTMGradMod1D(state_channels=T, hidden_dim=16, key=k2)
 
         result = one_step_solve_4dvarnet_1d(
             batch_1d, prior, grad_mod, n_steps=5, hidden_dim=16
@@ -134,8 +130,8 @@ class TestOneStepSolve4dvarnet1D:
 
         _B, T, N = batch_1d.input.shape
         k1, k2 = jax.random.split(rng)
-        prior = BilinAEPrior1D(state_dim=N, latent_dim=4, n_time=T, rngs=nnx.Rngs(k1))
-        grad_mod = ConvLSTMGradMod1D(state_channels=T, hidden_dim=16, rngs=nnx.Rngs(k2))
+        prior = BilinAEPrior1D(state_dim=N, latent_dim=4, n_time=T, key=k1)
+        grad_mod = ConvLSTMGradMod1D(state_channels=T, hidden_dim=16, key=k2)
 
         x0 = batch_1d.input * batch_1d.mask
         result = one_step_solve_4dvarnet_1d(
@@ -150,8 +146,8 @@ class TestOneStepSolve4dvarnet1D:
 
         _B, T, N = batch_1d.input.shape
         k1, k2 = jax.random.split(rng)
-        prior = BilinAEPrior1D(state_dim=N, latent_dim=4, n_time=T, rngs=nnx.Rngs(k1))
-        grad_mod = ConvLSTMGradMod1D(state_channels=T, hidden_dim=16, rngs=nnx.Rngs(k2))
+        prior = BilinAEPrior1D(state_dim=N, latent_dim=4, n_time=T, key=k1)
+        grad_mod = ConvLSTMGradMod1D(state_channels=T, hidden_dim=16, key=k2)
 
         def loss_fn(prior, grad_mod):
             x_hat = one_step_solve_4dvarnet_1d(
@@ -159,12 +155,14 @@ class TestOneStepSolve4dvarnet1D:
             )
             return jnp.mean((x_hat - batch_1d.target) ** 2)
 
-        grads = nnx.grad(loss_fn, argnums=(0, 1))(prior, grad_mod)
-        prior_grads, grad_mod_grads = grads
-        # at least some parameter gradients should be non-zero
-        prior_leaves = jax.tree_util.tree_leaves(nnx.state(prior_grads))
+        import equinox as eqx
+
+        # eqx.filter_grad keeps array leaves, drops non-array params
+        grads_p = eqx.filter_grad(lambda p: loss_fn(p, grad_mod))(prior)
+        grads_g = eqx.filter_grad(lambda g: loss_fn(prior, g))(grad_mod)
+        prior_leaves = jax.tree_util.tree_leaves(eqx.filter(grads_p, eqx.is_array))
         assert any(jnp.any(g != 0) for g in prior_leaves)
-        grad_mod_leaves = jax.tree_util.tree_leaves(nnx.state(grad_mod_grads))
+        grad_mod_leaves = jax.tree_util.tree_leaves(eqx.filter(grads_g, eqx.is_array))
         assert any(jnp.any(g != 0) for g in grad_mod_leaves)
 
     def test_single_step_equals_solver_step(self, rng, batch_1d):
@@ -179,8 +177,8 @@ class TestOneStepSolve4dvarnet1D:
 
         B, T, N = batch_1d.input.shape
         k1, k2 = jax.random.split(rng)
-        prior = BilinAEPrior1D(state_dim=N, latent_dim=4, n_time=T, rngs=nnx.Rngs(k1))
-        grad_mod = ConvLSTMGradMod1D(state_channels=T, hidden_dim=16, rngs=nnx.Rngs(k2))
+        prior = BilinAEPrior1D(state_dim=N, latent_dim=4, n_time=T, key=k1)
+        grad_mod = ConvLSTMGradMod1D(state_channels=T, hidden_dim=16, key=k2)
 
         result_one_step = one_step_solve_4dvarnet_1d(
             batch_1d, prior, grad_mod, n_steps=1, hidden_dim=16

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -1,6 +1,6 @@
 """Tests for vardax._src.training."""
 
-from flax import nnx
+import equinox as eqx
 import jax
 import jax.numpy as jnp
 import optax
@@ -19,10 +19,11 @@ def model_and_optimizer(rng, batch_1d):
         latent_dim=8,
         hidden_dim=16,
         n_solver_steps=2,
-        rngs=nnx.Rngs(rng),
+        key=rng,
     )
-    optimizer = nnx.Optimizer(model, optax.adam(1e-3), wrt=nnx.Param)
-    return model, optimizer
+    optimizer = optax.adam(1e-3)
+    opt_state = optimizer.init(eqx.filter(model, eqx.is_array))
+    return model, optimizer, opt_state
 
 
 class TestReconstructionLoss:
@@ -43,34 +44,34 @@ class TestReconstructionLoss:
 
 
 class TestTrainLossFn:
-    def test_returns_scalar(self, rng, batch_1d, model_and_optimizer):
-        model, _ = model_and_optimizer
+    def test_returns_scalar(self, batch_1d, model_and_optimizer):
+        model, _, _ = model_and_optimizer
         loss = train_loss_fn(model, batch_1d)
         assert loss.ndim == 0
         assert float(loss) >= 0.0
 
 
 class TestTrainStep:
-    def test_params_change(self, rng, batch_1d, model_and_optimizer):
-        model, optimizer = model_and_optimizer
-        params_before = jax.tree_util.tree_leaves(nnx.state(model, nnx.Param))
-        train_step(model, optimizer, batch_1d)
-        params_after = jax.tree_util.tree_leaves(nnx.state(model, nnx.Param))
+    def test_params_change(self, batch_1d, model_and_optimizer):
+        model, optimizer, opt_state = model_and_optimizer
+        params_before = jax.tree_util.tree_leaves(eqx.filter(model, eqx.is_array))
+        new_model, _, _ = train_step(model, batch_1d, optimizer, opt_state)
+        params_after = jax.tree_util.tree_leaves(eqx.filter(new_model, eqx.is_array))
         changed = any(
             not jnp.allclose(a, b)
             for a, b in zip(params_before, params_after, strict=True)
         )
         assert changed
 
-    def test_loss_is_finite(self, rng, batch_1d, model_and_optimizer):
-        model, optimizer = model_and_optimizer
-        loss = train_step(model, optimizer, batch_1d)
+    def test_loss_is_finite(self, batch_1d, model_and_optimizer):
+        model, optimizer, opt_state = model_and_optimizer
+        _, _, loss = train_step(model, batch_1d, optimizer, opt_state)
         assert jnp.isfinite(loss)
 
 
 class TestEvalStep:
     def test_returns_scalar(self, batch_1d, model_and_optimizer):
-        model, _ = model_and_optimizer
+        model, _, _ = model_and_optimizer
         loss = eval_step(model, batch_1d)
         assert loss.ndim == 0
         assert jnp.isfinite(loss)

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -18,9 +18,12 @@ class TestBatch1D:
         assert batch_1d.input.shape == batch_1d.mask.shape
         assert batch_1d.input.shape == batch_1d.target.shape
 
-    def test_is_named_tuple(self, batch_1d):
-        assert isinstance(batch_1d, tuple)
-        assert len(batch_1d) == 3
+    def test_is_pytree(self, batch_1d):
+        # Batch1D is now an eqx.Module (a JAX pytree, not a NamedTuple).
+        import jax
+
+        leaves = jax.tree_util.tree_leaves(batch_1d)
+        assert len(leaves) == 3
 
 
 class TestBatch2D:


### PR DESCRIPTION
## Summary

Phase 1 of the bulk implementation PR. Currently contains **Epic 0** (equinox migration) — the rest of Phase 1 (Epics 1, 2, 3, 6) will land as additional commits on this same branch. Marking draft so review can happen incrementally as commits push.

> [!IMPORTANT]
> **Draft.** Epic 0 is complete (all 147 existing tests pass on equinox). Epics 1 (protocols), 2 (observation operators), 3 (adjoint composition), and 6 (FourDVarNet refactor) will be added to this branch.

## Epic 0 — Equinox migration (this commit set)

Flax NNX is fully scrubbed from the source tree, tests, notebooks, and README. The remaining NNX references live in `docs/design/decisions.md` (Decision D1) and `docs/design/boundaries.md` (Epic 0 roadmap) — intentional history explaining *what was migrated from*.

| File | Change |
|---|---|
| `src/vardax/_src/priors.py` | `nnx.Module` → `eqx.Module`; `nnx.Linear` → `eqx.nn.Linear`; `nnx.Conv` (channels-last) → `eqx.nn.Conv1d`/`Conv2d` (channels-first, vmap over batch) |
| `src/vardax/_src/grad_mod.py` | ConvLSTMGradMod1D/2D ported with same channels-first conv pattern |
| `src/vardax/_src/model.py` | `FourDVarNet1D/2D` ported; static fields marked `eqx.field(static=True)` |
| `src/vardax/_src/training.py` | `nnx.Optimizer` → `optax` + `eqx.filter_value_and_grad`. `train_step` returns `(model, opt_state, loss)`. `fit()` **removed** per user guidance — vardax should not ship a manual training loop. |
| `src/vardax/_src/_types.py` | `Batch*` / `LSTMState*` converted from `NamedTuple` to `eqx.Module` |
| `src/vardax/_src/solver.py` | `SolverState*` converted to `eqx.Module` |
| `src/vardax/_src/adapters/pipekit_train.py` | **New** — `VardaxReconLoss` Loss adapter for `pipekit-train.TrainingLoop` |
| `src/vardax/_src/examples.py` | **New** — `fit_demo()` notebook-only training-loop helper (composes `train_step` inline; clearly marked as not library API) |
| `pyproject.toml` | Dropped `flax`, `jaxopt`. Added required: `optimistix`, `lineax`, `pipekit`, `pipekit-cycle`. Added extras: `[persist]` = `pipekit-jax` + `pipekit-experiment`; `[train]` = `pipekit-train` |
| `notebooks/01–08` | All 8 notebooks updated: `key=...` constructors, `optax`+`train_step` patterns, no `nnx.*` |
| `README.md` quickstart | NNX removed |
| `tests/*` | All 147 tests pass on equinox-migrated code |

## Still to come on this branch

| Epic | Plan |
|---|---|
| **1. Protocols** | `vardax/_src/protocols.py` re-exporting pipekit-cycle protocols + adding vardax-specific (`Prior`, `GradModulator`, `CostFunction`, `PosteriorAdapter`, `Minimiser`). `.as_analysis_step()` on FourDVarNet. `tests/test_pipekit_protocols.py`. |
| **2. Observation operators** | `vardax/_src/obs_operators/` — `MaskedIdentity`, `LinearObs`, `AveragingKernel`, `MultiInstrumentFusion`, `InstrumentRegistry`. Each with `__call__` + `linearize()`. Adjoint test. |
| **3. Adjoint composition** | Drop `grad_mode` enum from public API. Add `solver_adjoint`/`forward_adjoint` slots. Ship `vardax.adjoints.OneStepAdjoint` (Bolte 2023 as `optimistix.AbstractAdjoint`). |
| **6. FourDVarNet refactor** | FourDVarNet composes with Layer 1 protocols cleanly (mostly free given Epic 0+1). |
| Doc/notebook updates | Flip "planned (Epic X)" banners to "implemented" for what landed. |

## Test plan (current state)

- [x] `uv run pytest tests/ --no-cov -q` — 147 passed
- [x] `uv run ruff check .` — clean
- [x] `uv run ruff format --check .` — clean
- [x] `uv run ty check src/vardax` — clean
- [ ] Epic 1+2+3+6 commits (in progress on this branch)
- [ ] Full `pipekit_cycle.AnalysisStep` conformance once Epic 1 lands

---
_Generated by [Claude Code](https://claude.ai/code/session_013jMD55Uea3GA332USkaR7w)_