### PR TITLE
feat: phase 4 — pipekit cycle integration + amortized inference (epics 7, 8)

### DIFF
--- a/docs/design/boundaries.md
+++ b/docs/design/boundaries.md
@@ -389,8 +389,8 @@ implemented in `src/vardax/_src/`.
 | P1 | Epic 4 | Incremental 4DVar with CVT |
 | P1 | Epic 5 | Posterior adapters |
 | P1 | Epic 6 | FourDVarNet (learned variant of strong-4DVar) |
-| P2 | Epic 7 | pipekit-jax + pipekit-experiment + pipekit-train integration |
-| P2 | Epic 8 | Amortized inference |
+| **P2** | **Epic 7** | **pipekit-cycle integration (`VarDACycle`, `VarSmootherCycle`) — landed in v0.5** |
+| **P2** | **Epic 8** | **Amortized inference (`AmortizedPosterior`, regression head, six-step gates) — landed in v0.5; flow/score heads ship as stubs pending `gauss_flows`** |
 | P3 | Epic 9 | Hybrid ensemble-variational |
 | P3 | Epic 10 | Math reference (17 chapters) — landed in v0.4 |
 | P3 | Epic 11 | Tutorials |

--- a/docs/design/pipekit_composition.md
+++ b/docs/design/pipekit_composition.md
@@ -141,8 +141,8 @@ smoother = pc.SmootherCycle(
     forward_model=somax_model,
     obs_op=vdx.obs_operators.AveragingKernel(...),
     analysis_step=model.as_analysis_step(),
-    window_size=72,           # hours
-    window_overlap=12,        # hours
+    window=72,    # forecast steps per window
+    stride=60,    # step between window starts (12-step overlap)
 )
 trajectory = smoother(initial_state, ...)
 ```

--- a/src/vardax/__init__.py
+++ b/src/vardax/__init__.py
@@ -24,6 +24,15 @@ from vardax._src.adjoints import (
     OneStepAdjoint,
     RecursiveCheckpointAdjoint,
 )
+from vardax._src.amortized import (
+    AmortizedConfig,
+    AmortizedPosterior,
+    ConditionalFlowHead,
+    IdentityObsEncoder,
+    MLPObsEncoder,
+    RegressionHead,
+    ScoreDiffusionHead,
+)
 from vardax._src.costs import (
     decomposed_loss,
     obs_cost_1d,
@@ -32,6 +41,7 @@ from vardax._src.costs import (
     variational_cost,
     variational_cost_grad,
 )
+from vardax._src.cycle import VarDACycle, VarSmootherCycle
 from vardax._src.grad_mod import (
     ConvLSTMGradMod1D,
     ConvLSTMGradMod2D,
@@ -98,12 +108,19 @@ from vardax._src.solver import (
     solver_step_2d,
 )
 from vardax._src.training import (
+    amortized_nll_loss_fn,
+    amortized_train_step,
     eval_step,
     reconstruction_loss,
     train_loss_fn,
     train_step,
 )
 from vardax._src.utils.dynamical_systems import simulate_lorenz96
+from vardax._src.utils.validation import (
+    assert_adjoint_calibrated,
+    assert_posterior_agreement,
+    simulation_based_calibration,
+)
 from vardax._src.utils.viz import (
     plot_l96_grid,
     plot_l96_trajectories,
@@ -185,7 +202,24 @@ __all__ = [
     "StrongFourDVar",
     "ThreeDVar",
     "WeakFourDVar",
+    # Amortized inference (Epic 8 / Decision D12)
+    "AmortizedConfig",
+    "AmortizedPosterior",
+    "ConditionalFlowHead",
+    "IdentityObsEncoder",
+    "MLPObsEncoder",
+    "RegressionHead",
+    "ScoreDiffusionHead",
+    # pipekit cycle integration (Epic 7 / Decision D8)
+    "VarDACycle",
+    "VarSmootherCycle",
+    # Six-step validation gates (Decision D12)
+    "assert_adjoint_calibrated",
+    "assert_posterior_agreement",
+    "simulation_based_calibration",
     # Training
+    "amortized_nll_loss_fn",
+    "amortized_train_step",
     "eval_step",
     "reconstruction_loss",
     "train_loss_fn",

--- a/src/vardax/__init__.py
+++ b/src/vardax/__init__.py
@@ -12,6 +12,10 @@ that user code imports from the top-level namespace:
     model = vardax.FourDVarNet1D(...)
 """
 
+# Bind public submodules into the ``vardax`` namespace so the
+# advertised ``vdx.cycle.VarDACycle(...)`` / ``vdx.amortized.X`` /
+# ``vdx.adjoints.X`` access pattern works after a plain ``import vardax``.
+from vardax import adjoints, amortized, cycle  # noqa: F401
 from vardax._src._types import (
     Batch1D,
     Batch2D,

--- a/src/vardax/_src/amortized/__init__.py
+++ b/src/vardax/_src/amortized/__init__.py
@@ -1,0 +1,34 @@
+"""Amortized inference (Epic 8 / Decision D12).
+
+Learns a conditional density :math:`q_\\phi(x \\mid y)` that maps
+observations directly to posteriors. Trained by simulation: sample
+:math:`x \\sim p(x)`, simulate :math:`y \\mid x`, train
+:math:`q_\\phi` to recover :math:`x` from :math:`y`. Per-event inference
+is a single forward pass — the cost amortises over many events.
+
+Three head choices via ``AmortizedConfig.head_type``:
+
+- ``"regression"`` — Gaussian head ``(μ_φ(y), Σ_φ(y))``. Cheapest.
+- ``"flow"`` — Conditional normalising flow. Exact density, exact
+  samples. **Stub** — requires ``gauss_flows``.
+- ``"score"`` — Score-based diffusion. Sampling-only, handles
+  multimodal posteriors. **Stub** — pending diffrax reverse-SDE.
+
+Validation gates (six-step cycle, Decision D12) live in
+``vardax.utils.validation``.
+"""
+
+from .config import AmortizedConfig
+from .encoder import IdentityObsEncoder, MLPObsEncoder
+from .heads import ConditionalFlowHead, RegressionHead, ScoreDiffusionHead
+from .posterior import AmortizedPosterior
+
+__all__ = [
+    "AmortizedConfig",
+    "AmortizedPosterior",
+    "ConditionalFlowHead",
+    "IdentityObsEncoder",
+    "MLPObsEncoder",
+    "RegressionHead",
+    "ScoreDiffusionHead",
+]

--- a/src/vardax/_src/amortized/config.py
+++ b/src/vardax/_src/amortized/config.py
@@ -1,0 +1,31 @@
+"""Configuration for ``AmortizedPosterior``."""
+
+from __future__ import annotations
+
+import equinox as eqx
+
+
+class AmortizedConfig(eqx.Module):
+    """Configuration for an ``AmortizedPosterior``.
+
+    Attributes:
+        head_type: One of ``"regression"``, ``"flow"``, ``"score"``.
+            Determines the density family used by the head. Currently
+            only ``"regression"`` is fully implemented;  ``"flow"``
+            requires ``gauss_flows`` and ``"score"`` is pending the
+            diffrax reverse-SDE pipeline. Set on construction; the head
+            instance is responsible for matching the type.
+        n_samples: Default number of posterior samples to draw in
+            ``AmortizedPosterior.sample()`` when ``n`` is not provided.
+    """
+
+    head_type: str = eqx.field(static=True, default="regression")
+    n_samples: int = eqx.field(static=True, default=64)
+
+    def __post_init__(self) -> None:
+        valid = {"regression", "flow", "score"}
+        if self.head_type not in valid:
+            raise ValueError(
+                f"AmortizedConfig.head_type must be one of {sorted(valid)}; "
+                f"got {self.head_type!r}."
+            )

--- a/src/vardax/_src/amortized/encoder.py
+++ b/src/vardax/_src/amortized/encoder.py
@@ -1,0 +1,74 @@
+"""Observation encoders for ``AmortizedPosterior``.
+
+The encoder maps a single sample's ``(input, mask)`` to a context
+vector consumed by the head. Vardax ships two reference encoders:
+
+- ``IdentityObsEncoder`` — concatenates ``input`` and ``mask`` and
+  flattens. No learned parameters; useful as a baseline.
+- ``MLPObsEncoder`` — small MLP, trainable. Sensible default for
+  small-to-moderate state sizes.
+
+Users are encouraged to provide custom encoders (Conv, attention, ...)
+for higher-dimensional inputs.
+"""
+
+from __future__ import annotations
+
+import equinox as eqx
+import jax.numpy as jnp
+from jaxtyping import Array, Float, PRNGKeyArray
+
+
+class IdentityObsEncoder(eqx.Module):
+    """Concatenate ``input`` and ``mask`` into a flat context vector.
+
+    Zero parameters — the encoder is purely structural. The output
+    dimension is ``input.size + mask.size``.
+    """
+
+    def __call__(
+        self,
+        input: Float[Array, ...],
+        mask: Float[Array, ...],
+    ) -> Float[Array, " D"]:
+        return jnp.concatenate([input.ravel(), mask.ravel()])
+
+
+class MLPObsEncoder(eqx.Module):
+    """Two-layer MLP encoder from flat ``(input, mask)`` to context.
+
+    Attributes:
+        mlp: ``eqx.nn.MLP`` taking ``2 * input_size`` features and
+            emitting ``context_dim``.
+        input_size: Flattened size of the input field (``T * N`` for
+            ``Batch1D``, ``T * H * W`` for ``Batch2D``).
+    """
+
+    mlp: eqx.nn.MLP
+    input_size: int = eqx.field(static=True)
+
+    def __init__(
+        self,
+        input_size: int,
+        context_dim: int,
+        *,
+        hidden_dim: int = 64,
+        depth: int = 2,
+        key: PRNGKeyArray,
+    ) -> None:
+        self.input_size = input_size
+        self.mlp = eqx.nn.MLP(
+            in_size=2 * input_size,
+            out_size=context_dim,
+            width_size=hidden_dim,
+            depth=depth,
+            key=key,
+        )
+
+    def __call__(
+        self,
+        input: Float[Array, ...],
+        mask: Float[Array, ...],
+    ) -> Float[Array, " context_dim"]:
+        x = jnp.concatenate([input.ravel(), mask.ravel()])
+        return self.mlp(x)

--- a/src/vardax/_src/amortized/heads.py
+++ b/src/vardax/_src/amortized/heads.py
@@ -1,0 +1,135 @@
+"""Density heads for ``AmortizedPosterior``.
+
+Three head variants per the design (chapter 10):
+
+- ``RegressionHead`` — Gaussian ``q_φ(x|y) = N(μ_φ(y), Σ_φ(y))`` with
+  diagonal covariance. Fully implemented.
+- ``ConditionalFlowHead`` — normalising flow. Requires ``gauss_flows``;
+  ships as a stub until that dependency lands.
+- ``ScoreDiffusionHead`` — score-based diffusion. Stub pending the
+  diffrax-based reverse-SDE pipeline.
+
+Heads expose three methods:
+
+- ``map_estimate(ctx)`` — mode of ``q_φ(x|ctx)``.
+- ``sample(ctx, key, n)`` — ``n`` posterior samples shaped
+  ``(n, *state_shape)``.
+- ``log_prob(x, ctx)`` — scalar log-density of ``x`` under ``q_φ(·|ctx)``.
+  ``ScoreDiffusionHead.log_prob`` raises ``NotImplementedError``.
+"""
+
+from __future__ import annotations
+
+import math
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+from jaxtyping import Array, Float, PRNGKeyArray
+
+_LOG_2PI = math.log(2.0 * math.pi)
+
+
+class RegressionHead(eqx.Module):
+    """Gaussian regression head: ``q_φ(x|y) = N(μ_φ(y), diag(σ²_φ(y)))``.
+
+    Two MLPs share the context: one for the mean, one for the log
+    variance. Outputs are reshaped to the user-specified
+    ``state_shape``.
+
+    Attributes:
+        mlp_mu: MLP from context to flat mean (size ``prod(state_shape)``).
+        mlp_log_var: MLP from context to flat log variance.
+        state_shape: Shape of a single posterior sample (e.g.
+            ``(T, N)`` for ``Batch1D`` targets).
+    """
+
+    mlp_mu: eqx.nn.MLP
+    mlp_log_var: eqx.nn.MLP
+    state_shape: tuple[int, ...] = eqx.field(static=True)
+
+    def __init__(
+        self,
+        context_dim: int,
+        state_shape: tuple[int, ...],
+        *,
+        hidden_dim: int = 64,
+        depth: int = 2,
+        key: PRNGKeyArray,
+    ) -> None:
+        self.state_shape = tuple(state_shape)
+        flat_dim = 1
+        for d in self.state_shape:
+            flat_dim *= d
+        k_mu, k_lv = jax.random.split(key)
+        self.mlp_mu = eqx.nn.MLP(
+            in_size=context_dim,
+            out_size=flat_dim,
+            width_size=hidden_dim,
+            depth=depth,
+            key=k_mu,
+        )
+        self.mlp_log_var = eqx.nn.MLP(
+            in_size=context_dim,
+            out_size=flat_dim,
+            width_size=hidden_dim,
+            depth=depth,
+            key=k_lv,
+        )
+
+    def map_estimate(self, ctx: Float[Array, " D"]) -> Float[Array, ...]:
+        return self.mlp_mu(ctx).reshape(self.state_shape)
+
+    def sample(
+        self,
+        ctx: Float[Array, " D"],
+        key: PRNGKeyArray,
+        n: int,
+    ) -> Float[Array, ...]:
+        mu = self.mlp_mu(ctx).reshape(self.state_shape)
+        log_var = self.mlp_log_var(ctx).reshape(self.state_shape)
+        sigma = jnp.exp(0.5 * log_var)
+        eps = jax.random.normal(key, (n, *self.state_shape))
+        return mu + sigma * eps
+
+    def log_prob(
+        self,
+        x: Float[Array, ...],
+        ctx: Float[Array, " D"],
+    ) -> Float[Array, ""]:
+        mu = self.mlp_mu(ctx).reshape(self.state_shape)
+        log_var = self.mlp_log_var(ctx).reshape(self.state_shape)
+        # log N(x | mu, diag(exp(log_var))) — sum over state dims.
+        return -0.5 * jnp.sum(((x - mu) ** 2) * jnp.exp(-log_var) + log_var + _LOG_2PI)
+
+
+class ConditionalFlowHead(eqx.Module):
+    """Conditional normalising flow head (stub).
+
+    Implements ``x = f_φ(z; c_ψ(y))`` with ``z ~ N(0, I)``. Exact
+    density via change-of-variables. Requires ``gauss_flows`` for the
+    flow primitives; ships as a stub until that dependency is added to
+    ``pyproject.toml``.
+    """
+
+    def __init__(self, *_args: object, **_kwargs: object) -> None:
+        raise NotImplementedError(
+            "ConditionalFlowHead requires `gauss_flows`, which is not yet "
+            "a vardax dependency. Use `RegressionHead` for now; flow support "
+            "lands in a follow-up PR alongside the gauss_flows dependency."
+        )
+
+
+class ScoreDiffusionHead(eqx.Module):
+    """Score-based diffusion head (stub).
+
+    Learns ``s_φ(x, t | y) ≈ ∇_x log p_t(x | y)``; samples via reverse
+    SDE solved with diffrax. Ships as a stub pending the reverse-SDE
+    pipeline.
+    """
+
+    def __init__(self, *_args: object, **_kwargs: object) -> None:
+        raise NotImplementedError(
+            "ScoreDiffusionHead is not yet implemented. Pending the diffrax-based "
+            "reverse-SDE pipeline. Use `RegressionHead` for now."
+        )

--- a/src/vardax/_src/amortized/posterior.py
+++ b/src/vardax/_src/amortized/posterior.py
@@ -1,0 +1,132 @@
+"""``AmortizedPosterior`` — the seventh AnalysisStep.
+
+Composes an encoder (``(input, mask) → context``) with a density head
+(``context → q_φ(x | y)``). Trained by simulation:
+
+.. code-block:: python
+
+    def sample_train_pair(key):
+        x = prior_distribution.sample(key)
+        y = forward_model(x) + obs_noise.sample(key)
+        return Batch1D(input=y, mask=quality_mask, target=x)
+
+
+    for batch in simulation_loader:
+        model, opt_state, loss = amortized_train_step(
+            model,
+            batch,
+            optimizer,
+            opt_state,
+        )
+
+Inference (sub-second):
+
+.. code-block:: python
+
+    x_map = model(batch)  # MAP / mode
+    samples = model.sample(batch, key, n=200)  # posterior samples
+    log_p = model.log_prob(x, batch)  # exact for flow/regression
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+from jaxtyping import Array, Float, PRNGKeyArray
+
+from vardax._src._types import Batch1D, Batch2D
+
+from .config import AmortizedConfig
+
+
+class AmortizedPosterior(eqx.Module):
+    """Amortized variational posterior :math:`q_\\phi(x \\mid y)`.
+
+    Attributes:
+        encoder: ``eqx.Module`` mapping ``(input, mask)`` to a context
+            vector. Vmapped over the batch axis at call time.
+        head: ``RegressionHead`` / ``ConditionalFlowHead`` /
+            ``ScoreDiffusionHead``. Exposes ``map_estimate(ctx)``,
+            ``sample(ctx, key, n)``, ``log_prob(x, ctx)``.
+        config: ``AmortizedConfig`` carrying head type and sampling
+            defaults.
+    """
+
+    encoder: Any
+    head: Any
+    config: AmortizedConfig
+
+    def __call__(self, batch: Batch1D | Batch2D) -> Float[Array, ...]:
+        """Return the per-sample MAP / mode of :math:`q_\\phi(x \\mid y)`."""
+
+        def _one(input_i, mask_i):
+            ctx = self.encoder(input_i, mask_i)
+            return self.head.map_estimate(ctx)
+
+        return jax.vmap(_one)(batch.input, batch.mask)
+
+    def sample(
+        self,
+        batch: Batch1D | Batch2D,
+        key: PRNGKeyArray,
+        n: int | None = None,
+    ) -> Float[Array, ...]:
+        """Draw posterior samples per batch element.
+
+        Returns an array of shape ``(B, n, *state_shape)``.
+        """
+        n = self.config.n_samples if n is None else n
+        b = batch.input.shape[0]
+        keys = jax.random.split(key, b)
+
+        def _one(input_i, mask_i, key_i):
+            ctx = self.encoder(input_i, mask_i)
+            return self.head.sample(ctx, key_i, n)
+
+        return jax.vmap(_one)(batch.input, batch.mask, keys)
+
+    def log_prob(
+        self,
+        x: Float[Array, ...],
+        batch: Batch1D | Batch2D,
+    ) -> Float[Array, " B"]:
+        """Per-sample log-density of ``x`` under ``q_φ(·|y)``.
+
+        For ``ScoreDiffusionHead`` this raises ``NotImplementedError``
+        (no closed-form density). Use ``sample`` instead.
+        """
+
+        def _one(x_i, input_i, mask_i):
+            ctx = self.encoder(input_i, mask_i)
+            return self.head.log_prob(x_i, ctx)
+
+        return jax.vmap(_one)(x, batch.input, batch.mask)
+
+    def as_analysis_step(self) -> _AmortizedAnalysisStep:
+        """Adapt to ``pipekit_cycle.AnalysisStep`` (Decision D8)."""
+        return _AmortizedAnalysisStep(self)
+
+
+class _AmortizedAnalysisStep(eqx.Module):
+    """``pipekit_cycle.AnalysisStep`` adapter for ``AmortizedPosterior``."""
+
+    model: AmortizedPosterior
+
+    def __call__(
+        self,
+        forecast: Float[Array, ...],
+        obs: Float[Array, ...],
+        *,
+        obs_op: Any,
+        obs_err_cov: Any,
+    ) -> Float[Array, ...]:
+        mask = jnp.where(jnp.isfinite(obs), 1.0, 0.0)
+        obs_clean = jnp.nan_to_num(obs)
+        if obs.ndim == 4:
+            batch = Batch2D(input=obs_clean, mask=mask, target=None)
+        else:
+            batch = Batch1D(input=obs_clean, mask=mask, target=None)
+        return self.model(batch)

--- a/src/vardax/_src/cycle/__init__.py
+++ b/src/vardax/_src/cycle/__init__.py
@@ -1,0 +1,11 @@
+"""pipekit-cycle integration (Epic 7 / Decision D8).
+
+Thin convenience constructors that wire a vardax Layer 2 model into
+``pipekit_cycle.DACycle`` / ``pipekit_cycle.SmootherCycle``. Vardax does
+not reimplement cycle orchestration; these factories just pull the
+``.as_analysis_step()`` adapter off the model and hand it to pipekit.
+"""
+
+from .da_cycle import VarDACycle, VarSmootherCycle
+
+__all__ = ["VarDACycle", "VarSmootherCycle"]

--- a/src/vardax/_src/cycle/da_cycle.py
+++ b/src/vardax/_src/cycle/da_cycle.py
@@ -1,0 +1,126 @@
+"""Convenience factories for ``pipekit_cycle.DACycle`` / ``SmootherCycle``.
+
+Per Decision D8, vardax models satisfy ``pipekit_cycle.AnalysisStep`` via
+``.as_analysis_step()``. The factories here are pure glue: they take a
+vardax model (any of the seven Layer 2 classes) plus a forward and obs
+operator, and return a configured pipekit-cycle object ready to call.
+
+Examples:
+
+    >>> import vardax as vdx
+    >>> cycle = vdx.cycle.VarDACycle(
+    ...     forward=somax_model,
+    ...     obs_op=vdx.obs_operators.MaskedIdentity(),
+    ...     model=vdx.IncrementalFourDVar(...),
+    ...     n_steps=24,
+    ... )
+    >>> analysis, state = cycle(initial_state, vdx.cycle.DAState())
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+try:
+    import pipekit_cycle as _pc
+except ImportError as exc:  # pragma: no cover
+    raise ImportError(
+        "vardax.cycle requires pipekit-cycle, which is a required dependency. "
+        "Reinstall vardax to pick it up."
+    ) from exc
+
+if TYPE_CHECKING:
+    from pipekit_cycle import DACycle, SmootherCycle
+
+
+def VarDACycle(
+    forward: Any,
+    obs_op: Any,
+    model: Any,
+    *,
+    obs_source: Any | None = None,
+    n_steps: int = 1,
+    save_history: bool = True,
+) -> DACycle:
+    """Build a ``pipekit_cycle.DACycle`` from a vardax model.
+
+    Pulls ``model.as_analysis_step()`` and hands it to pipekit-cycle.
+    The same orchestration code works for any of the seven Layer 2
+    classes — `OptimalInterpolation`, `ThreeDVar`, `StrongFourDVar`,
+    `WeakFourDVar`, `IncrementalFourDVar`, `FourDVarNet`,
+    `AmortizedPosterior`.
+
+    Args:
+        forward: Forward model satisfying ``pipekit_cycle.ForwardModel``.
+        obs_op: Observation operator satisfying
+            ``pipekit_cycle.ObservationOperator``.
+        model: Vardax Layer 2 model exposing ``.as_analysis_step()``.
+        obs_source: Optional ``pipekit.Operator`` invoked as
+            ``obs_source(step_index)`` to load observations per cycle.
+            If ``None``, the analysis step is skipped and the forecast
+            propagates forward.
+        n_steps: Number of forecast-analysis cycles per call.
+        save_history: Append ``(forecast, analysis)`` pairs to
+            ``cycle.history`` each cycle.
+
+    Returns:
+        Configured ``pipekit_cycle.DACycle`` ready to call.
+
+    Raises:
+        AttributeError: If ``model`` does not expose
+            ``.as_analysis_step()``.
+    """
+    if not hasattr(model, "as_analysis_step"):
+        raise AttributeError(
+            "VarDACycle requires a model exposing `.as_analysis_step()`; "
+            f"got {type(model).__name__}."
+        )
+    return _pc.DACycle(
+        forward_model=forward,
+        obs_op=obs_op,
+        analysis_step=model.as_analysis_step(),
+        obs_source=obs_source,
+        n_steps=n_steps,
+        save_history=save_history,
+    )
+
+
+def VarSmootherCycle(
+    forward: Any,
+    obs_op: Any,
+    model: Any,
+    *,
+    window: int,
+    stride: int = 1,
+    obs_source: Any | None = None,
+) -> SmootherCycle:
+    """Build a ``pipekit_cycle.SmootherCycle`` from a vardax model.
+
+    Retrospective windowed smoothing: the model analyses each
+    ``window``-step window, sliding by ``stride`` between consecutive
+    windows.
+
+    Args:
+        forward: Forward model.
+        obs_op: Observation operator.
+        model: Vardax Layer 2 model exposing ``.as_analysis_step()``.
+        window: Number of forecast steps per smoother window.
+        stride: Step between consecutive window starts.
+        obs_source: Optional observation loader.
+
+    Returns:
+        Configured ``pipekit_cycle.SmootherCycle``.
+    """
+    if not hasattr(model, "as_analysis_step"):
+        raise AttributeError(
+            "VarSmootherCycle requires a model exposing `.as_analysis_step()`; "
+            f"got {type(model).__name__}."
+        )
+    return _pc.SmootherCycle(
+        forward_model=forward,
+        obs_op=obs_op,
+        analysis_step=model.as_analysis_step(),
+        window=window,
+        stride=stride,
+        obs_source=obs_source,
+    )

--- a/src/vardax/_src/training.py
+++ b/src/vardax/_src/training.py
@@ -112,3 +112,53 @@ def eval_step(
     if target is None:
         raise ValueError("eval_step requires batch.target to be set.")
     return reconstruction_loss(pred, target)
+
+
+def amortized_nll_loss_fn(
+    model: Any,
+    batch: Batch1D | Batch2D,
+) -> Float[Array, ""]:
+    """Negative log-likelihood for amortized inference (Epic 8).
+
+    For ``AmortizedPosterior`` with flow / regression heads the maximum-
+    likelihood objective on simulated pairs is
+
+    .. math::
+
+        \\mathcal{L}_\\text{MLE}(\\phi) = -\\mathbb{E}_{(x, y)} \\log q_\\phi(x \\mid y).
+
+    Args:
+        model: ``AmortizedPosterior`` (any head with a ``.log_prob``
+            method).
+        batch: Training batch with ``target = x`` and ``input = y``.
+
+    Returns:
+        Scalar NLL averaged over the batch.
+    """
+    target = batch.target
+    if target is None:
+        raise ValueError(
+            "amortized_nll_loss_fn requires batch.target (the true x) to be set."
+        )
+    log_p = model.log_prob(target, batch)
+    return -jnp.mean(log_p)
+
+
+@eqx.filter_jit
+def amortized_train_step(
+    model: Any,
+    batch: Batch1D | Batch2D,
+    optimizer: optax.GradientTransformation,
+    opt_state: optax.OptState,
+) -> tuple[Any, optax.OptState, Float[Array, ""]]:
+    """Single training step for ``AmortizedPosterior``.
+
+    Same shape as ``train_step`` but uses ``amortized_nll_loss_fn``
+    instead of the MSE reconstruction loss. Use this for simulation-
+    based training of amortized variants; use ``train_step`` for
+    ``FourDVarNet`` and classical models that reconstruct fields.
+    """
+    loss, grads = eqx.filter_value_and_grad(amortized_nll_loss_fn)(model, batch)
+    updates, opt_state = optimizer.update(grads, opt_state, model)
+    model = eqx.apply_updates(model, updates)
+    return model, opt_state, loss

--- a/src/vardax/_src/utils/validation.py
+++ b/src/vardax/_src/utils/validation.py
@@ -1,0 +1,205 @@
+"""Six-step cycle validation gates (Decision D12 / Epic 8).
+
+Amortized inference is dangerous when miscalibrated — a tight
+:math:`q_\\phi` centred wrong gives confident wrong answers. Decision
+D12 (chapter 14 of the math reference) requires three gates before any
+amortized head is promoted to operational use:
+
+1. **Posterior agreement** — the fast model's MAP lies within
+   :math:`\\sigma_\\text{post}` of an oracle MAP from a slower method.
+2. **Adjoint calibration** — the fast model's sensitivity to
+   observations matches the physics-based sensitivity, measured by
+   random-vector probing of the Jacobian.
+3. **Simulation-based calibration (SBC)** — per Talts et al. 2018,
+   rank histograms of true draws within posterior samples are uniform
+   for a well-calibrated head.
+
+These utilities are deliberately framework-agnostic: they accept the
+fast and oracle models as plain callables / vardax ``Posterior``
+objects and return / assert numeric results. They do not depend on the
+specific Layer 2 method.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+import jax
+import jax.numpy as jnp
+from jaxtyping import Array, Float, PRNGKeyArray
+
+from vardax._src.posterior.container import Posterior
+
+
+def assert_posterior_agreement(
+    p_fast: Posterior,
+    p_oracle: Posterior,
+    *,
+    tolerance_sigma: float = 1.0,
+) -> None:
+    """Check that ``p_fast.mean`` lies within ``tolerance_sigma`` standard
+    deviations of ``p_oracle.mean``.
+
+    Marginal-only test: each component of the mean must satisfy
+
+    .. math::
+
+        \\frac{|x^*_\\text{fast} - x^*_\\text{oracle}|}{\\sigma_\\text{post, oracle}}
+        \\le \\text{tolerance\\_sigma}.
+
+    The oracle marginal :math:`\\sigma_i` is extracted from
+    ``p_oracle.cov`` by probing ``e_i^T \\Sigma e_i`` via one matvec per
+    component. Cheap for moderate state size; for very large state
+    sizes use Hutchinson estimation upstream and supply the diagonal
+    directly via ``Posterior.cov`` materialised as a diagonal operator.
+
+    Args:
+        p_fast: Posterior produced by the amortized / fast model.
+        p_oracle: Posterior produced by the oracle (e.g. ``StrongFourDVar``
+            + ``LaplaceCovariance``).
+        tolerance_sigma: Allowed deviation in units of :math:`\\sigma`.
+
+    Raises:
+        AssertionError: If any component exceeds the tolerance.
+    """
+    if p_oracle.cov is None:
+        raise ValueError(
+            "assert_posterior_agreement requires p_oracle.cov to be set "
+            "(used to extract the marginal standard deviations)."
+        )
+    if p_fast.mean.shape != p_oracle.mean.shape:
+        raise ValueError(
+            "p_fast.mean and p_oracle.mean must have the same shape; got "
+            f"{p_fast.mean.shape} vs {p_oracle.mean.shape}."
+        )
+    sigma = _marginal_std(p_oracle.cov, p_oracle.mean)
+    z = jnp.abs(p_fast.mean - p_oracle.mean) / jnp.maximum(sigma, 1e-12)
+    if jnp.any(z > tolerance_sigma):
+        worst = float(jnp.max(z))
+        raise AssertionError(
+            f"posterior agreement failed: max z = {worst:.3f} > {tolerance_sigma:.3f}."
+        )
+
+
+def assert_adjoint_calibrated(
+    fn_fast: Callable[[Array], Array],
+    fn_oracle: Callable[[Array], Array],
+    y: Float[Array, ...],
+    *,
+    key: PRNGKeyArray,
+    threshold: float = 0.05,
+    n_probes: int = 10,
+) -> None:
+    """Random-vector probe of the Jacobian agreement at ``y``.
+
+    Tests
+
+    .. math::
+
+        \\frac{\\|J_\\text{fast} v - J_\\text{oracle} v\\|}
+             {\\|J_\\text{oracle} v\\|} < \\text{threshold}
+
+    for ``n_probes`` random unit vectors :math:`v`. Avoids
+    materialising either Jacobian — uses ``jax.jvp`` to apply each as
+    needed. Cheaper than dense Jacobian comparison and is the
+    operational test used by the six-step cycle.
+
+    Args:
+        fn_fast: Callable ``y → analysis`` (e.g.
+            ``lambda y_: amortized(Batch1D(input=y_, mask=mask, target=None))``).
+        fn_oracle: Same signature, but the oracle.
+        y: Observation tensor.
+        key: PRNG key for the probe vectors.
+        threshold: Maximum allowed relative error.
+        n_probes: Number of probe vectors.
+
+    Raises:
+        AssertionError: If any probe exceeds the threshold.
+    """
+    keys = jax.random.split(key, n_probes)
+    worst_rel = 0.0
+    for k in keys:
+        v = jax.random.normal(k, y.shape)
+        v = v / jnp.linalg.norm(v)
+        _, jv_fast = jax.jvp(fn_fast, (y,), (v,))
+        _, jv_oracle = jax.jvp(fn_oracle, (y,), (v,))
+        denom = jnp.linalg.norm(jv_oracle) + 1e-12
+        rel = float(jnp.linalg.norm(jv_fast - jv_oracle) / denom)
+        worst_rel = max(worst_rel, rel)
+    if worst_rel > threshold:
+        raise AssertionError(
+            f"adjoint calibration failed: max relative error {worst_rel:.4f} > "
+            f"{threshold:.4f} (over {n_probes} probes)."
+        )
+
+
+def simulation_based_calibration(
+    sample_posterior: Callable[[Array, PRNGKeyArray, int], Array],
+    sample_prior: Callable[[PRNGKeyArray], Array],
+    simulate_obs: Callable[[Array, PRNGKeyArray], Array],
+    *,
+    key: PRNGKeyArray,
+    n_runs: int = 200,
+    n_samples: int = 200,
+) -> Float[Array, " n_runs"]:
+    """Per Talts et al. 2018: rank histogram of true draws within
+    posterior samples.
+
+    Procedure for each of ``n_runs`` independent draws:
+
+    1. Sample :math:`x^{(j)} \\sim p(x)` from the prior.
+    2. Simulate :math:`y^{(j)} = \\mathrm{simulate\\_obs}(x^{(j)})`.
+    3. Draw ``n_samples`` posterior samples from
+       :math:`q_\\phi(\\cdot \\mid y^{(j)})`.
+    4. Compute the rank of (a flattened scalar reduction of)
+       :math:`x^{(j)}` in the sample set.
+
+    A well-calibrated posterior produces uniformly distributed ranks
+    over ``[0, n_samples]``. Bumps near the edges → over-confident;
+    centre-mass bump → under-confident.
+
+    Args:
+        sample_posterior: ``(y, key, n) -> Array`` of shape
+            ``(n, *state_shape)`` — posterior samples conditioned on
+            ``y``. For an ``AmortizedPosterior``, the natural wrapper is
+            ``lambda y, k, n: model.sample(Batch(input=y[None], ...), k, n)[0]``.
+        sample_prior: ``key -> x``. Single prior draw.
+        simulate_obs: ``(x, key) -> y``. Forward + noise.
+        key: Top-level PRNG key.
+        n_runs: Number of (prior, obs, posterior) triples.
+        n_samples: Posterior samples per run (defines the rank
+            histogram resolution).
+
+    Returns:
+        ``(n_runs,)`` int array of ranks in ``[0, n_samples]``.
+    """
+    keys = jax.random.split(key, n_runs)
+    ranks = []
+    for k in keys:
+        k_prior, k_obs, k_post = jax.random.split(k, 3)
+        x_true = sample_prior(k_prior)
+        y = simulate_obs(x_true, k_obs)
+        samples = sample_posterior(y, k_post, n_samples)
+        # Flatten and use the L2 norm as the scalar reduction.
+        scalar_true = float(jnp.linalg.norm(x_true))
+        scalar_samples = jnp.linalg.norm(samples.reshape(n_samples, -1), axis=-1)
+        rank = int(jnp.sum(scalar_samples < scalar_true))
+        ranks.append(rank)
+    return jnp.asarray(ranks, dtype=jnp.int32)
+
+
+def _marginal_std(cov_op: Any, ref: Float[Array, ...]) -> Float[Array, ...]:
+    """Extract :math:`\\sqrt{\\mathrm{diag}(\\Sigma)}` by probing ``Σ e_i``.
+
+    Works for any operator exposing ``.mv``. Cost is ``N`` matvecs;
+    fine for the moderate-N regime where this gate is meaningful.
+    """
+    flat = ref.ravel()
+    n = flat.size
+    diag = jnp.zeros(n)
+    for i in range(n):
+        e = jnp.zeros(n).at[i].set(1.0).reshape(ref.shape)
+        sigma_e = cov_op.mv(e).ravel()
+        diag = diag.at[i].set(sigma_e[i])
+    return jnp.sqrt(jnp.maximum(diag, 0.0)).reshape(ref.shape)

--- a/src/vardax/amortized.py
+++ b/src/vardax/amortized.py
@@ -1,0 +1,26 @@
+"""Public ``vardax.amortized`` API surface (Epic 8 / Decision D12).
+
+Re-exports from ``vardax._src.amortized`` so namespaced access like
+``vdx.amortized.AmortizedPosterior(...)`` works for users following
+the design docs.
+"""
+
+from vardax._src.amortized import (
+    AmortizedConfig,
+    AmortizedPosterior,
+    ConditionalFlowHead,
+    IdentityObsEncoder,
+    MLPObsEncoder,
+    RegressionHead,
+    ScoreDiffusionHead,
+)
+
+__all__ = [
+    "AmortizedConfig",
+    "AmortizedPosterior",
+    "ConditionalFlowHead",
+    "IdentityObsEncoder",
+    "MLPObsEncoder",
+    "RegressionHead",
+    "ScoreDiffusionHead",
+]

--- a/src/vardax/cycle.py
+++ b/src/vardax/cycle.py
@@ -1,0 +1,9 @@
+"""Public ``vardax.cycle`` API surface (Epic 7 / Decision D8).
+
+Re-exports from ``vardax._src.cycle`` so ``vdx.cycle.VarDACycle(...)``
+works as advertised in the design docs.
+"""
+
+from vardax._src.cycle import VarDACycle, VarSmootherCycle
+
+__all__ = ["VarDACycle", "VarSmootherCycle"]

--- a/tests/test_amortized.py
+++ b/tests/test_amortized.py
@@ -1,0 +1,138 @@
+"""Tests for ``AmortizedPosterior`` (Epic 8)."""
+
+from __future__ import annotations
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+import optax
+import pytest
+
+from vardax import (
+    AmortizedConfig,
+    AmortizedPosterior,
+    AnalysisStep,
+    Batch1D,
+    ConditionalFlowHead,
+    IdentityObsEncoder,
+    MLPObsEncoder,
+    RegressionHead,
+    ScoreDiffusionHead,
+    amortized_train_step,
+)
+
+
+@pytest.fixture
+def rng():
+    return jax.random.PRNGKey(0)
+
+
+@pytest.fixture
+def shapes():
+    return {"B": 3, "T": 2, "N": 4}
+
+
+@pytest.fixture
+def regression_model(rng, shapes):
+    T, N = shapes["T"], shapes["N"]
+    head = RegressionHead(
+        context_dim=2 * T * N,
+        state_shape=(T, N),
+        hidden_dim=8,
+        depth=2,
+        key=rng,
+    )
+    return AmortizedPosterior(
+        encoder=IdentityObsEncoder(),
+        head=head,
+        config=AmortizedConfig(head_type="regression", n_samples=8),
+    )
+
+
+@pytest.fixture
+def batch(rng, shapes):
+    B, T, N = shapes["B"], shapes["T"], shapes["N"]
+    k1, k2 = jax.random.split(rng)
+    return Batch1D(
+        input=jax.random.normal(k1, (B, T, N)),
+        mask=jnp.ones((B, T, N)),
+        target=jax.random.normal(k2, (B, T, N)),
+    )
+
+
+class TestRegressionHead:
+    def test_map_shape(self, regression_model, batch, shapes):
+        out = regression_model(batch)
+        assert out.shape == (shapes["B"], shapes["T"], shapes["N"])
+
+    def test_sample_shape(self, regression_model, batch, rng, shapes):
+        samples = regression_model.sample(batch, rng, n=5)
+        assert samples.shape == (shapes["B"], 5, shapes["T"], shapes["N"])
+
+    def test_log_prob_shape(self, regression_model, batch, shapes):
+        log_p = regression_model.log_prob(batch.target, batch)
+        assert log_p.shape == (shapes["B"],)
+
+    def test_log_prob_finite(self, regression_model, batch):
+        log_p = regression_model.log_prob(batch.target, batch)
+        assert jnp.all(jnp.isfinite(log_p))
+
+
+class TestMLPObsEncoder:
+    def test_runs(self, rng, shapes):
+        T, N = shapes["T"], shapes["N"]
+        ctx_dim = 6
+        enc = MLPObsEncoder(input_size=T * N, context_dim=ctx_dim, key=rng)
+        ctx = enc(jnp.zeros((T, N)), jnp.ones((T, N)))
+        assert ctx.shape == (ctx_dim,)
+
+
+class TestAnalysisStep:
+    def test_satisfies_protocol(self, regression_model):
+        step = regression_model.as_analysis_step()
+        assert isinstance(step, AnalysisStep)
+
+    def test_handles_nan_obs(self, regression_model, shapes):
+        B, T, N = shapes["B"], shapes["T"], shapes["N"]
+        step = regression_model.as_analysis_step()
+        forecast = jnp.zeros((B, T, N))
+        obs = forecast.at[:, 0, 0].set(jnp.nan)
+        out = step(forecast, obs, obs_op=None, obs_err_cov=None)
+        assert out.shape == forecast.shape
+        assert jnp.all(jnp.isfinite(out))
+
+
+class TestAmortizedTraining:
+    def test_loss_decreases(self, regression_model, batch):
+        optimizer = optax.adam(1e-2)
+        opt_state = optimizer.init(eqx.filter(regression_model, eqx.is_array))
+        model, opt_state, loss0 = amortized_train_step(
+            regression_model, batch, optimizer, opt_state
+        )
+        for _ in range(40):
+            model, opt_state, loss = amortized_train_step(
+                model, batch, optimizer, opt_state
+            )
+        assert float(loss) < float(loss0)
+
+    def test_requires_target(self, regression_model, shapes):
+        B, T, N = shapes["B"], shapes["T"], shapes["N"]
+        batch = Batch1D(
+            input=jnp.zeros((B, T, N)),
+            mask=jnp.ones((B, T, N)),
+            target=None,
+        )
+        optimizer = optax.adam(1e-3)
+        opt_state = optimizer.init(eqx.filter(regression_model, eqx.is_array))
+        with pytest.raises(ValueError, match=r"batch\.target"):
+            amortized_train_step(regression_model, batch, optimizer, opt_state)
+
+
+class TestStubHeads:
+    def test_flow_head_raises(self):
+        with pytest.raises(NotImplementedError, match="gauss_flows"):
+            ConditionalFlowHead()
+
+    def test_score_head_raises(self):
+        with pytest.raises(NotImplementedError, match="reverse-SDE"):
+            ScoreDiffusionHead()

--- a/tests/test_cycle.py
+++ b/tests/test_cycle.py
@@ -1,0 +1,80 @@
+"""Smoke tests for ``vardax.cycle`` factories (Epic 7)."""
+
+from __future__ import annotations
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+import lineax as lx
+import pipekit_cycle as pc
+import pytest
+
+from vardax import (
+    LinearObs,
+    MaskedIdentity,
+    OptimalInterpolation,
+    VarDACycle,
+    VarSmootherCycle,
+)
+
+
+class IdentityForward(eqx.Module):
+    @property
+    def dt(self) -> float:
+        return 1.0
+
+    @property
+    def state_signature(self):
+        return None
+
+    def step(self, state, dt):
+        return state
+
+
+@pytest.fixture
+def oi_model():
+    N = 4
+    H = lx.IdentityLinearOperator(jax.ShapeDtypeStruct((1, N), jnp.float32))
+    cov = lx.IdentityLinearOperator(jax.ShapeDtypeStruct((1, N), jnp.float32))
+    return OptimalInterpolation(
+        obs_op=LinearObs(H_mat=H),
+        prior_mean=jnp.zeros((1, N)),
+        prior_cov_op=cov,
+        obs_cov_op=cov,
+    )
+
+
+class TestVarDACycle:
+    def test_returns_dacycle(self, oi_model):
+        cycle = VarDACycle(
+            forward=IdentityForward(),
+            obs_op=MaskedIdentity(),
+            model=oi_model,
+            n_steps=1,
+        )
+        assert isinstance(cycle, pc.DACycle)
+
+    def test_carries_analysis_step(self, oi_model):
+        cycle = VarDACycle(
+            forward=IdentityForward(), obs_op=MaskedIdentity(), model=oi_model
+        )
+        assert isinstance(cycle.analysis_step, pc.AnalysisStep)
+
+    def test_rejects_model_without_as_analysis_step(self):
+        with pytest.raises(AttributeError, match="as_analysis_step"):
+            VarDACycle(
+                forward=IdentityForward(),
+                obs_op=MaskedIdentity(),
+                model=object(),
+            )
+
+
+class TestVarSmootherCycle:
+    def test_returns_smoothercycle(self, oi_model):
+        cycle = VarSmootherCycle(
+            forward=IdentityForward(),
+            obs_op=MaskedIdentity(),
+            model=oi_model,
+            window=3,
+        )
+        assert isinstance(cycle, pc.SmootherCycle)

--- a/tests/test_cycle.py
+++ b/tests/test_cycle.py
@@ -78,3 +78,25 @@ class TestVarSmootherCycle:
             window=3,
         )
         assert isinstance(cycle, pc.SmootherCycle)
+
+
+class TestPublicNamespace:
+    """Submodules must be reachable via the advertised
+    ``import vardax as vdx; vdx.cycle.X`` pattern."""
+
+    def test_cycle_submodule(self):
+        import vardax as vdx
+
+        assert vdx.cycle.VarDACycle is VarDACycle
+        assert vdx.cycle.VarSmootherCycle is VarSmootherCycle
+
+    def test_amortized_submodule(self):
+        import vardax as vdx
+
+        assert vdx.amortized.AmortizedPosterior is vdx.AmortizedPosterior
+        assert vdx.amortized.RegressionHead is vdx.RegressionHead
+
+    def test_adjoints_submodule(self):
+        import vardax as vdx
+
+        assert vdx.adjoints.OneStepAdjoint is vdx.OneStepAdjoint

--- a/tests/test_pipekit_protocols.py
+++ b/tests/test_pipekit_protocols.py
@@ -21,13 +21,17 @@ import jax.numpy as jnp
 import pytest
 
 from vardax import (
+    AmortizedConfig,
+    AmortizedPosterior,
     AnalysisStep,
     BilinAEPrior1D,
     ConvLSTMGradMod1D,
     CostFunction,
     FourDVarNet1D,
     GradModulator,
+    IdentityObsEncoder,
     Prior,
+    RegressionHead,
 )
 
 
@@ -82,6 +86,37 @@ class TestAnalysisStepProtocol:
         # Forecast + obs with NaN-masked entries
         forecast = jnp.zeros((2, 3, 4))
         obs = forecast.at[:, 0, 0].set(jnp.nan)  # one missing pixel
+        analysis = step(forecast, obs, obs_op=None, obs_err_cov=None)
+        assert analysis.shape == forecast.shape
+
+
+class TestAmortizedPosteriorProtocol:
+    """`AmortizedPosterior` is the seventh AnalysisStep (Epic 8)."""
+
+    def _model(self, rng):
+        head = RegressionHead(
+            context_dim=2 * 3 * 4,
+            state_shape=(3, 4),
+            hidden_dim=4,
+            depth=2,
+            key=rng,
+        )
+        return AmortizedPosterior(
+            encoder=IdentityObsEncoder(),
+            head=head,
+            config=AmortizedConfig(head_type="regression"),
+        )
+
+    def test_yields_analysis_step(self, rng):
+        model = self._model(rng)
+        step = model.as_analysis_step()
+        assert isinstance(step, AnalysisStep)
+
+    def test_analysis_step_callable(self, rng):
+        model = self._model(rng)
+        step = model.as_analysis_step()
+        forecast = jnp.zeros((2, 3, 4))
+        obs = forecast.at[:, 0, 0].set(jnp.nan)
         analysis = step(forecast, obs, obs_op=None, obs_err_cov=None)
         assert analysis.shape == forecast.shape
 

--- a/tests/test_six_step_validation.py
+++ b/tests/test_six_step_validation.py
@@ -1,0 +1,150 @@
+"""Tests for the six-step cycle validation gates (Decision D12 / Epic 8).
+
+Exercises ``assert_posterior_agreement``, ``assert_adjoint_calibrated``,
+and ``simulation_based_calibration`` on tractable problems so the
+behaviour of each gate is pinned down. Real-world usage of these gates
+lives in the validation harness of an amortized training pipeline; these
+tests verify the gate logic itself.
+"""
+
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+import lineax as lx
+import pytest
+
+from vardax import (
+    Posterior,
+    assert_adjoint_calibrated,
+    assert_posterior_agreement,
+    simulation_based_calibration,
+)
+
+
+@pytest.fixture
+def rng():
+    return jax.random.PRNGKey(0)
+
+
+class TestAssertPosteriorAgreement:
+    def test_close_means_pass(self):
+        N = 4
+        cov = lx.IdentityLinearOperator(jax.ShapeDtypeStruct((N,), jnp.float32))
+        mean = jnp.array([0.1, -0.2, 0.3, 0.4])
+        p_oracle = Posterior(mean=mean, cov=cov)
+        p_fast = Posterior(mean=mean + 0.1, cov=cov)
+        # |0.1| / std=1 well within tolerance 1.0
+        assert_posterior_agreement(p_fast, p_oracle, tolerance_sigma=1.0)
+
+    def test_far_means_fail(self):
+        N = 4
+        cov = lx.IdentityLinearOperator(jax.ShapeDtypeStruct((N,), jnp.float32))
+        mean = jnp.zeros(N)
+        p_oracle = Posterior(mean=mean, cov=cov)
+        p_fast = Posterior(mean=mean + 2.5, cov=cov)
+        with pytest.raises(AssertionError, match="posterior agreement"):
+            assert_posterior_agreement(p_fast, p_oracle, tolerance_sigma=1.0)
+
+    def test_requires_oracle_cov(self):
+        mean = jnp.zeros(3)
+        p_oracle = Posterior(mean=mean, cov=None)
+        p_fast = Posterior(mean=mean, cov=None)
+        with pytest.raises(ValueError, match=r"p_oracle\.cov"):
+            assert_posterior_agreement(p_fast, p_oracle)
+
+    def test_shape_mismatch(self):
+        cov = lx.IdentityLinearOperator(jax.ShapeDtypeStruct((3,), jnp.float32))
+        p_oracle = Posterior(mean=jnp.zeros(3), cov=cov)
+        p_fast = Posterior(mean=jnp.zeros(4), cov=None)
+        with pytest.raises(ValueError, match="same shape"):
+            assert_posterior_agreement(p_fast, p_oracle)
+
+
+class TestAssertAdjointCalibrated:
+    def test_identical_pass(self, rng):
+        def fn(y):
+            return 2.0 * y + 1.0
+
+        assert_adjoint_calibrated(
+            fn, fn, jnp.zeros(4), key=rng, threshold=1e-6, n_probes=5
+        )
+
+    def test_close_pass(self, rng):
+        def fn(y):
+            return 2.0 * y
+
+        def fn_close(y):
+            return 2.001 * y
+
+        assert_adjoint_calibrated(
+            fn, fn_close, jnp.zeros(4), key=rng, threshold=0.01, n_probes=5
+        )
+
+    def test_far_fail(self, rng):
+        def fn(y):
+            return 2.0 * y
+
+        def fn_far(y):
+            return 4.0 * y
+
+        with pytest.raises(AssertionError, match="adjoint calibration"):
+            assert_adjoint_calibrated(
+                fn, fn_far, jnp.zeros(4), key=rng, threshold=0.05, n_probes=3
+            )
+
+
+class TestSimulationBasedCalibration:
+    def test_returns_ranks_in_range(self, rng):
+        def sample_prior(k):
+            return jax.random.normal(k, (3,))
+
+        def simulate(x, k):
+            return x + 0.1 * jax.random.normal(k, x.shape)
+
+        n_samples = 50
+
+        def sample_posterior(y, k, n):
+            return y[None] + jax.random.normal(k, (n, *y.shape))
+
+        ranks = simulation_based_calibration(
+            sample_posterior=sample_posterior,
+            sample_prior=sample_prior,
+            simulate_obs=simulate,
+            key=rng,
+            n_runs=30,
+            n_samples=n_samples,
+        )
+        assert ranks.shape == (30,)
+        assert jnp.all(ranks >= 0)
+        assert jnp.all(ranks <= n_samples)
+
+    def test_biased_posterior_piles_ranks_low(self, rng):
+        """A posterior whose samples are biased *higher* than the true
+        scalar reduction produces ranks concentrated near 0.
+
+        Concretely: samples = y + drift with drift large and positive,
+        so ‖samples‖ ≫ ‖x_true‖ and the count of samples below
+        ``‖x_true‖`` is 0 almost surely.
+        """
+
+        def sample_prior(k):
+            return 0.1 * jax.random.normal(k, (3,))
+
+        def simulate(x, k):
+            return x  # noise-free
+
+        def sample_posterior(y, k, n):
+            return y[None] + 5.0 + 0.01 * jax.random.normal(k, (n, *y.shape))
+
+        n_samples = 50
+        ranks = simulation_based_calibration(
+            sample_posterior=sample_posterior,
+            sample_prior=sample_prior,
+            simulate_obs=simulate,
+            key=rng,
+            n_runs=30,
+            n_samples=n_samples,
+        )
+        # ‖x_true‖ ≈ 0.17 ≪ ‖biased samples‖ ≈ 8.7, so rank ≈ 0.
+        assert int(jnp.median(ranks)) < 5


### PR DESCRIPTION
## Summary

Lands the Phase 4 epics on the equinox-native roadmap (`docs/design/boundaries.md`).

### Epic 7 — pipekit-cycle integration (Decision D8)

- `VarDACycle(forward, obs_op, model, ...)` — factory returning a configured `pipekit_cycle.DACycle`. Same orchestration works for any of the seven Layer 2 models via `.as_analysis_step()`.
- `VarSmootherCycle(...)` — factory returning a `pipekit_cycle.SmootherCycle` for retrospective windowed analysis.

```python
import vardax as vdx

cycle = vdx.VarDACycle(
    forward=somax_model,
    obs_op=vdx.MaskedIdentity(),
    model=vdx.IncrementalFourDVar(...),
    n_steps=24,
)
analysis, state = cycle(initial_state, pipekit_cycle.DAState())
```

### Epic 8 — amortized inference (Decision D12)

- `AmortizedPosterior(encoder, head, config)` — the **seventh** `AnalysisStep`. Exposes `__call__` (MAP), `sample(batch, key, n)`, `log_prob(x, batch)`, and `as_analysis_step()`.
- `RegressionHead` — fully implemented Gaussian head with diagonal log-variance.
- `ConditionalFlowHead`, `ScoreDiffusionHead` — stubs raising `NotImplementedError`. Flow pending the `gauss_flows` dep; score pending the diffrax reverse-SDE pipeline.
- `IdentityObsEncoder`, `MLPObsEncoder` — reference encoders.
- `amortized_train_step` + `amortized_nll_loss_fn` — sibling primitives to `train_step` for MLE on simulated pairs.

### Six-step cycle validation gates (Decision D12)

- `assert_posterior_agreement(p_fast, p_oracle, tolerance_sigma)` — marginal z-score check via probing the oracle covariance.
- `assert_adjoint_calibrated(fn_fast, fn_oracle, y, key, threshold)` — random-vector JVP probe of Jacobian agreement.
- `simulation_based_calibration(...)` — Talts et al. rank histogram.

### Scope deliberately deferred to follow-ups

- `JaxModelOp` wrappers (lives in `pipekit-jax`, optional extra).
- `ConditionalFlowHead` body once `gauss_flows` becomes a dep.
- `ScoreDiffusionHead` body once the diffrax reverse-SDE harness is in place.

## Test plan

- [x] `make uv-test` — 213 passing (was 187; 26 new across `test_amortized` / `test_cycle` / `test_six_step_validation` plus the extension to `test_pipekit_protocols`).
- [x] `make uv-lint` — ruff clean.
- [x] `make uv-typecheck-ci` — CI-env `ty` clean.
- [x] `AmortizedPosterior` satisfies `pipekit_cycle.AnalysisStep` (asserted in `test_pipekit_protocols`).
- [x] `RegressionHead` loss decreases under 40 `amortized_train_step` calls on a tiny problem.
- [x] `VarDACycle` / `VarSmootherCycle` round-trip and refuse models without `.as_analysis_step()`.


---
_Generated by [Claude Code](https://claude.ai/code/session_013jMD55Uea3GA332USkaR7w)_