### PR TITLE
refactor: pin gaussx 0.0.18 and delegate linear-algebra primitives to it

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -221,7 +221,7 @@ source = ["src/vardax"]
 output = "reports/coverage.xml"
 
 [tool.uv.sources]
-gaussx = { git = "https://github.com/jejjohnson/gaussx" }
+gaussx = { git = "https://github.com/jejjohnson/gaussx", rev = "cd6264c" }
 pipekit = { git = "https://github.com/jejjohnson/pipekit", subdirectory = "packages/pipekit" }
 pipekit-cycle = { git = "https://github.com/jejjohnson/pipekit", subdirectory = "packages/pipekit-cycle" }
 pipekit-jax = { git = "https://github.com/jejjohnson/pipekit", subdirectory = "packages/pipekit-jax" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,6 @@ dependencies = [
     "jaxlib>=0.5",
     "optax>=0.2",
     "jaxtyping>=0.2.28",
-    "einops>=0.8",
     "diffrax>=0.5",
     "equinox>=0.11",
     "optimistix>=0.1",

--- a/src/vardax/_src/models/incremental_fourdvar.py
+++ b/src/vardax/_src/models/incremental_fourdvar.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 from typing import Any
 
 import equinox as eqx
+import gaussx
 import jax
 import jax.numpy as jnp
 from jaxtyping import Array, Float
@@ -217,16 +218,16 @@ class IncrementalFourDVar(eqx.Module):
 
 
 def _inv(op: lx.AbstractLinearOperator) -> lx.AbstractLinearOperator:
-    """Lazy inverse of a positive-semidefinite operator via lineax.CG."""
+    """Lazy PSD inverse — gaussx.inv (structured closed forms, CG fallback).
 
-    def _solve(v):
-        return lx.linear_solve(
-            lx.TaggedLinearOperator(op, lx.positive_semidefinite_tag),
-            v,
-            solver=lx.CG(atol=1e-6, rtol=1e-6, max_steps=200),
-        ).value
-
-    return lx.FunctionLinearOperator(_solve, op.in_structure())
+    Re-wrapped as a ``FunctionLinearOperator`` so lineax can linearise
+    it inside composed operators that are themselves solved.
+    """
+    inv_op = gaussx.inv(
+        lx.TaggedLinearOperator(op, lx.positive_semidefinite_tag),
+        solver=lx.CG(atol=1e-6, rtol=1e-6, max_steps=200),
+    )
+    return lx.FunctionLinearOperator(inv_op.mv, op.in_structure())
 
 
 def _accepts_mask(obs_op: Any) -> bool:

--- a/src/vardax/_src/posterior/adapter.py
+++ b/src/vardax/_src/posterior/adapter.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 from typing import Any
 
 import equinox as eqx
-import jax.numpy as jnp
+import gaussx
 import numpy as np
 
 from .container import Posterior
@@ -60,8 +60,10 @@ class GaussianMarkLikelihood(eqx.Module):
         else fall back to a single ``as_matrix()`` call.
         """
         cov = self.posterior.cov
+        if cov is None:
+            return None
         try:
-            return jnp.diag(cov.as_matrix())  # type: ignore[union-attr]  # ty:ignore[unresolved-attribute]
+            return gaussx.diag(cov)
         except (AttributeError, NotImplementedError):
             # Lazy operators don't always materialise; just emit a
             # null marker.

--- a/src/vardax/_src/posterior/ensemble.py
+++ b/src/vardax/_src/posterior/ensemble.py
@@ -21,9 +21,9 @@ from __future__ import annotations
 from typing import Any
 
 import equinox as eqx
+import gaussx
 import jax.numpy as jnp
 from jaxtyping import Array, Float
-import lineax as lx
 
 from .container import Posterior
 
@@ -67,11 +67,13 @@ class EnsembleCovariance(eqx.Module):
             pass
 
         mean = jnp.mean(analyses, axis=0)
-        # Flatten everything but the leading ensemble dim, then
-        # compute sample covariance.
-        flat = analyses.reshape(m, -1) - mean.reshape(1, -1)
-        cov_mat = self.inflation * (flat.T @ flat) / (m - 1)
-        cov_op = lx.MatrixLinearOperator(cov_mat, lx.positive_semidefinite_tag)
+        # Flatten everything but the leading ensemble dim; the
+        # Bessel-corrected sample covariance comes from gaussx as a
+        # rank-(m-1) LowRankUpdate operator (never dense), scaled by
+        # the multiplicative inflation factor.
+        cov_op = self.inflation * gaussx.ensemble_covariance(
+            analyses.reshape(m, -1), bessel=True
+        )
 
         return Posterior(
             mean=mean,

--- a/src/vardax/_src/posterior/gauss_newton.py
+++ b/src/vardax/_src/posterior/gauss_newton.py
@@ -18,11 +18,12 @@ from __future__ import annotations
 from typing import Any
 
 import equinox as eqx
+import gaussx
 from jaxtyping import Array, Float
 import lineax as lx
 
 from .container import Posterior
-from .laplace import _inverse_op
+from .laplace import _CG_SOLVER, _inverse_op
 
 
 class GaussNewtonHessian(eqx.Module):
@@ -68,7 +69,7 @@ class GaussNewtonHessian(eqx.Module):
 
         return Posterior(
             mean=analysis,
-            cov=_inverse_op(precision_tagged),
+            cov=gaussx.inv(precision_tagged, solver=_CG_SOLVER),
             samples=None,
             provenance={
                 "adapter": "GaussNewtonHessian",

--- a/src/vardax/_src/posterior/laplace.py
+++ b/src/vardax/_src/posterior/laplace.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 from typing import Any
 
 import equinox as eqx
+import gaussx
 from jaxtyping import Array, Float
 import lineax as lx
 
@@ -82,9 +83,10 @@ class LaplaceCovariance(eqx.Module):
 
         H = obs_op.linearize(analysis)
         # P*^{-1} = H^T R^{-1} H + B^{-1}
-        # Build lazily — represent as the inverse of a composed
-        # AbstractLinearOperator. Concrete mat-vec evaluation is via
-        # lineax.CG on the precision operator.
+        # Build lazily via operator composition (gaussx.sandwich would
+        # materialise the Jacobian, breaking the matrix-free design);
+        # the inverses are gaussx.inv, which dispatches to closed forms
+        # for structured operators and falls back to lineax.CG mat-vecs.
         precision = H.transpose() @ _inverse_op(self.obs_cov_op) @ H + _inverse_op(
             self.prior_cov_op
         )
@@ -94,33 +96,28 @@ class LaplaceCovariance(eqx.Module):
 
         return Posterior(
             mean=analysis,
-            cov=_InverseLinearOperator(precision_tagged),
+            cov=gaussx.inv(precision_tagged, solver=_CG_SOLVER),
             samples=None,
             provenance={"adapter": "LaplaceCovariance"},
         )
 
 
+_CG_SOLVER = lx.CG(atol=1e-6, rtol=1e-6, max_steps=200)
+
+
 def _inverse_op(op: lx.AbstractLinearOperator) -> lx.AbstractLinearOperator:
-    """Lazy inverse: a wrapper that applies ``op^{-1}`` via lineax.CG."""
-    return _InverseLinearOperator(
-        lx.TaggedLinearOperator(op, lx.positive_semidefinite_tag)
-    )
+    """Lazy PSD inverse — delegates to :func:`gaussx.inv`.
 
-
-class _InverseLinearOperator(lx.FunctionLinearOperator):
-    """Inverse of a positive-semidefinite operator, applied via CG.
-
-    Wraps any ``AbstractLinearOperator`` ``A`` such that mat-vec
-    returns ``A^{-1} v`` (solved by ``lineax.CG``). The inverse is
-    never materialised.
+    Structured operators (diagonal, Kronecker, block-diagonal,
+    low-rank) invert in closed form; everything else solves via
+    ``lineax.CG`` mat-vecs, never materialising the inverse. The
+    gaussx operator is re-wrapped as a ``FunctionLinearOperator`` so
+    lineax can linearise it when it appears inside a composed
+    precision that is itself solved (gaussx's ``InverseOperator``
+    does not register ``lx.linearise``).
     """
-
-    def __init__(self, op: lx.AbstractLinearOperator) -> None:
-        def _solve(v: Float[Array, ...]) -> Float[Array, ...]:
-            return lx.linear_solve(
-                op, v, solver=lx.CG(atol=1e-6, rtol=1e-6, max_steps=200)
-            ).value
-
-        # FunctionLinearOperator needs an input_structure; reuse the
-        # underlying operator's.
-        super().__init__(_solve, op.in_structure())
+    inv_op = gaussx.inv(
+        lx.TaggedLinearOperator(op, lx.positive_semidefinite_tag),
+        solver=_CG_SOLVER,
+    )
+    return lx.FunctionLinearOperator(inv_op.mv, op.in_structure())

--- a/src/vardax/_src/utils/validation.py
+++ b/src/vardax/_src/utils/validation.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from typing import Any
 
+import gaussx
 import jax
 import jax.numpy as jnp
 from jaxtyping import Array, Float, PRNGKeyArray
@@ -190,16 +191,12 @@ def simulation_based_calibration(
 
 
 def _marginal_std(cov_op: Any, ref: Float[Array, ...]) -> Float[Array, ...]:
-    """Extract :math:`\\sqrt{\\mathrm{diag}(\\Sigma)}` by probing ``Σ e_i``.
+    """Extract :math:`\\sqrt{\\mathrm{diag}(\\Sigma)}` from the operator.
 
-    Works for any operator exposing ``.mv``. Cost is ``N`` matvecs;
-    fine for the moderate-N regime where this gate is meaningful.
+    Delegates to :func:`gaussx.diag`, which uses closed forms for
+    structured operators (diagonal, Kronecker, block-diagonal) and
+    falls back to materialisation only for generic operators — fine
+    for the moderate-N regime where this gate is meaningful.
     """
-    flat = ref.ravel()
-    n = flat.size
-    diag = jnp.zeros(n)
-    for i in range(n):
-        e = jnp.zeros(n).at[i].set(1.0).reshape(ref.shape)
-        sigma_e = cov_op.mv(e).ravel()
-        diag = diag.at[i].set(sigma_e[i])
+    diag = gaussx.diag(cov_op)
     return jnp.sqrt(jnp.maximum(diag, 0.0)).reshape(ref.shape)

--- a/tests/test_pipekit_protocols.py
+++ b/tests/test_pipekit_protocols.py
@@ -129,3 +129,54 @@ class TestCostFunctionProtocol:
             return jnp.sum(x**2)
 
         assert isinstance(cost, CostFunction)
+
+
+class TestObservationOperatorConformance:
+    """Obs operators satisfy ``pipekit_cycle.ObservationOperator`` (D8)."""
+
+    def test_linear_obs(self):
+        import lineax as lx
+
+        from vardax import LinearObs, ObservationOperator
+
+        op = LinearObs(H_mat=lx.MatrixLinearOperator(jnp.eye(3)))
+        assert isinstance(op, ObservationOperator)
+        assert isinstance(op.linearize(jnp.zeros(3)), lx.AbstractLinearOperator)
+
+    def test_masked_identity(self):
+        from vardax import MaskedIdentity, ObservationOperator
+
+        op = MaskedIdentity()
+        assert isinstance(op, ObservationOperator)
+
+    def test_averaging_kernel(self):
+        import lineax as lx
+
+        from vardax import AveragingKernel, ObservationOperator
+
+        op = AveragingKernel(
+            A=lx.MatrixLinearOperator(0.5 * jnp.eye(3)),
+            x_a=jnp.zeros(3),
+            h=jnp.ones(3),
+        )
+        assert isinstance(op, ObservationOperator)
+
+    def test_multi_instrument_flattened_wrapper(self):
+        import lineax as lx
+
+        from vardax import (
+            InstrumentRegistry,
+            InstrumentSpec,
+            LinearObs,
+            MultiInstrumentFusion,
+            ObservationOperator,
+        )
+
+        spec = InstrumentSpec(
+            obs_op=LinearObs(H_mat=lx.MatrixLinearOperator(jnp.eye(2))),
+            mask=jnp.ones(2),
+            R_op=lx.DiagonalLinearOperator(0.1 * jnp.ones(2)),
+            instrument_id="a",
+        )
+        fusion = MultiInstrumentFusion(registry=InstrumentRegistry(entries={"a": spec}))
+        assert isinstance(fusion.to_observation_operator(), ObservationOperator)


### PR DESCRIPTION
## Summary

Same treatment as filterax (jejjohnson/filterax#91): update to the latest gaussx, delegate duplicated math to it, and tighten pipekit protocol usage.

### gaussx pinned to `cd6264c` (0.0.18)
The git dependency floated to HEAD and `uv.lock` is gitignored, so builds were unpinned. Now pinned to the same rev filterax uses.

### DRY: hand-rolled math → gaussx
vardax declared gaussx as a dependency but **never imported it**. Now the primitives route through gaussx's structure-aware dispatch, with the matrix-free design intact:

- **Lazy PSD inverses** (Laplace, Gauss-Newton, IncrementalFourDVar): the hand-rolled CG `FunctionLinearOperator` wrappers delegate to `gaussx.inv` with the same CG tolerances — gaining closed-form inverses for diagonal/Kronecker/block-diagonal/low-rank covariances. The result is re-wrapped as a lineax `FunctionLinearOperator` because gaussx's `InverseOperator` doesn't register `lx.linearise`, which lineax needs when the inverse sits inside a composed precision that is itself solved.
- **`EnsembleCovariance`**: the dense `(N, N)` sample covariance becomes `gaussx.ensemble_covariance` — a rank-(m−1) `LowRankUpdate` scaled by the inflation factor, never materialised.
- **Covariance diagonals**: the O(N) unit-vector probe loop in the SBC validation gate and the `as_matrix()` fallback in the posterior serialiser both become `gaussx.diag`.

**Deliberately not delegated** (documented in code):
- The `H B Hᵀ` / `Hᵀ R⁻¹ H` sandwiches stay as lazy lineax compositions — `gaussx.sandwich` materialises the Jacobian via `as_matrix()` in its generic path, which would break the matrix-free design (the test suite caught this when tried).
- The amortized head's diagonal Gaussian log-density keeps its log-variance parameterisation for numerical precision.

### pipekit protocols
vardax already conforms broadly: all 8 analysis methods expose `as_analysis_step()` (`AnalysisStep`), obs operators implement `ObservationOperator` with real `linearize()`, and `VarDACycle`/`VarSmootherCycle` are thin factories over pipekit's own cycles. The gap filled here: the conformance suite never isinstance-checked the obs operators — added tests for `LinearObs`, `MaskedIdentity`, `AveragingKernel`, and `MultiInstrumentFusion.to_observation_operator()` against `pipekit_cycle.ObservationOperator`.

### Cleanup
Dropped the `einops` dependency (declared, never imported anywhere).

## Test plan
- [x] `uv run pytest` — 220 passed (216 baseline + 4 new conformance tests)
- [x] `ruff check .` / `ruff format --check .` — clean
- [x] `ty check src/vardax` — clean

https://claude.ai/code/session_018xVoXd1zzxK6cZGbSUgakd

---
_Generated by [Claude Code](https://claude.ai/code/session_018xVoXd1zzxK6cZGbSUgakd)_