### PR TITLE
docs: generated API reference and MkDocs-compatible docstrings

### DIFF
--- a/docs/api/amortized.md
+++ b/docs/api/amortized.md
@@ -1,0 +1,46 @@
+# Amortized Inference
+
+Where the variational methods on the [Models](models.md) page solve an
+optimisation problem *per analysis*, an amortized posterior pays the cost
+once at training time: a network is fit to map observations directly to an
+approximate posterior, so inference is a single forward pass. See
+[Amortized Inference](../10_amortized_inference.md) in the Mathematical
+Reference for the underlying theory and the fidelity/speed trade-offs.
+
+`AmortizedPosterior` composes two exchangeable parts: an *observation
+encoder* that summarises (possibly masked, possibly irregular) observations
+into a conditioning vector, and a *posterior head* that turns that vector
+into a distribution over states. Heads span the fidelity ladder — point
+estimates (`RegressionHead`), full densities via conditional normalizing
+flows (`ConditionalFlowHead`), and score-based diffusion sampling
+(`ScoreDiffusionHead`). Amortized posteriors should pass the same
+[validation gates](utils.md) (simulation-based calibration, posterior
+agreement) as their variational counterparts.
+
+## Posterior and configuration
+
+::: vardax
+    options:
+      show_root_heading: false
+      show_root_toc_entry: false
+      members: [AmortizedPosterior, AmortizedConfig]
+
+## Observation encoders
+
+`IdentityObsEncoder` passes observations straight through — appropriate
+when they are already a fixed-size vector; `MLPObsEncoder` learns the
+summary.
+
+::: vardax
+    options:
+      show_root_heading: false
+      show_root_toc_entry: false
+      members: [IdentityObsEncoder, MLPObsEncoder]
+
+## Posterior heads
+
+::: vardax
+    options:
+      show_root_heading: false
+      show_root_toc_entry: false
+      members: [RegressionHead, ConditionalFlowHead, ScoreDiffusionHead]

--- a/docs/api/costs_priors.md
+++ b/docs/api/costs_priors.md
@@ -1,0 +1,55 @@
+# Costs, Priors & Solvers
+
+The functional core under the [model classes](models.md): pure cost
+functions that score a candidate state against observations and prior,
+prior modules that supply the regularisation term, and the inner-loop
+solver functions that drive the [4DVarNet](../09_4dvarnet.md) iteration.
+The model classes are thin, stateful-looking wrappers over these pieces —
+drop down to this layer when building custom methods or instrumenting the
+optimisation.
+
+## Cost functions
+
+The variational cost $J(x) = J_\text{obs}(x) + J_\text{prior}(x)$ and its
+gradient, with the observation and prior terms also available separately
+(`decomposed_loss` returns them unsummed for logging). The `_1d` / `_2d`
+suffixes match the [`Batch1D` / `Batch2D`](protocols.md) carriers. See
+[3DVar](../05_threedvar.md) and
+[strong-constraint 4DVar](../06_strong_4dvar.md) for the math each term
+implements.
+
+::: vardax
+    options:
+      show_root_heading: false
+      show_root_toc_entry: false
+      members: [variational_cost, variational_cost_grad, obs_cost_1d, obs_cost_2d, prior_cost, decomposed_loss]
+
+## Priors
+
+Implementations of the [`Prior`](protocols.md) Protocol. `IdentityPrior`
+gives plain Tikhonov regularisation; `L63Prior` / `L96Prior` encode Lorenz
+dynamics as a model-consistency penalty; the autoencoder priors (MLP,
+convolutional, and bilinear variants in 1D, 2D, and 2D-multivariate) are
+*learned* priors that penalise distance from a trained reconstruction
+manifold.
+
+::: vardax
+    options:
+      show_root_heading: false
+      show_root_toc_entry: false
+      members: [IdentityPrior, L63Prior, L96Prior, MLPAEPrior1D, ConvAEPrior1D, BilinAEPrior1D, BilinAEPrior2D, BilinAEPrior2DMultivar]
+
+## 4DVarNet inner-loop solvers
+
+The unrolled (and fixed-point) inner loop of 4DVarNet, exposed as pure
+functions over an explicit `SolverState`: initialise with
+`init_solver_state_*`, advance one modulated-gradient step with
+`solver_step_*` (or `fp_solver_step_1d` for the fixed-point formulation),
+or run the whole loop with `solve_4dvarnet_*`. The `one_step_*` variants
+pair with [`OneStepAdjoint`](training.md) for memory-frugal training.
+
+::: vardax
+    options:
+      show_root_heading: false
+      show_root_toc_entry: false
+      members: [SolverState1D, SolverState2D, init_solver_state_1d, init_solver_state_2d, solver_step_1d, solver_step_2d, fp_solver_step_1d, solve_4dvarnet_1d, solve_4dvarnet_2d, solve_4dvarnet_1d_fixedpoint, one_step_solve_4dvarnet_1d, one_step_solve_4dvarnet_2d]

--- a/docs/api/cycle.md
+++ b/docs/api/cycle.md
@@ -1,0 +1,26 @@
+# Cycle Integration
+
+Sequential assimilation — forecast, observe, analyse, repeat — is
+orchestrated by [pipekit-cycle](https://github.com/jejjohnson/pipekit), not
+reimplemented here. The two factories on this page are thin wrappers that
+assemble a `pipekit_cycle.DACycle` (filtering) or
+`pipekit_cycle.SmootherCycle` (fixed-lag smoothing) from vardax parts: any
+[model](models.md)'s `.as_analysis_step()`, any
+[observation operator](obs_operators.md), and a forward model satisfying
+the [`ForwardModel`](protocols.md) Protocol.
+
+Because the coupling is purely structural (runtime-checkable Protocols, no
+inheritance), the same cycle accepts every vardax method interchangeably —
+swapping [3DVar](../05_threedvar.md) for
+[strong-constraint 4DVar](../06_strong_4dvar.md) inside a cycle is a
+one-argument change. The full forecast/analysis loop is worked through in
+[Six-Step Inference Cycle](../14_six_step_cycle.md). Both factories are also
+accessible via the `vardax.cycle` submodule namespace.
+
+## Factories
+
+::: vardax
+    options:
+      show_root_heading: false
+      show_root_toc_entry: false
+      members: [VarDACycle, VarSmootherCycle]

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -1,0 +1,50 @@
+# API Reference
+
+vardax is JAX-native variational data assimilation: seven peer analysis
+methods — from [Optimal Interpolation](../04_oi_blue.md) through
+[learned 4DVarNet](../09_4dvarnet.md) — plus the observation operators,
+priors, posterior adapters, and training loops that surround them. The
+reference is organised by area rather than dumped as one flat page:
+
+| Section | What's inside |
+|---------|---------------|
+| [Models](models.md) | The seven peer analysis methods — `OptimalInterpolation`, `ThreeDVar`, `StrongFourDVar`, `WeakFourDVar`, `IncrementalFourDVar`, `FourDVarNet1D`, `FourDVarNet2D` |
+| [Amortized Inference](amortized.md) | `AmortizedPosterior` and its observation encoders and posterior heads (regression, conditional flow, score diffusion) |
+| [Observation Operators](obs_operators.md) | `LinearObs`, `MaskedIdentity`, `AveragingKernel`, multi-instrument fusion, and the instrument registry |
+| [Posterior Covariance](posterior.md) | The `Posterior` container and the Laplace / Gauss-Newton / ensemble adapters that build it |
+| [Costs, Priors & Solvers](costs_priors.md) | Variational cost functions, learned and analytic priors, and the 4DVarNet inner-loop solver functions |
+| [Training & Adjoints](training.md) | Loss functions and train/eval steps, adjoint strategies, and ConvLSTM gradient modulators |
+| [Cycle Integration](cycle.md) | `VarDACycle` / `VarSmootherCycle` factories over pipekit-cycle |
+| [Protocols & Types](protocols.md) | The structural Protocols every component satisfies, plus the batch and LSTM-state type aliases |
+| [Utilities & Diagnostics](utils.md) | Lorenz-96 simulation, six-step validation gates (SBC and friends), and plotting helpers |
+
+## Import conventions
+
+Everything documented here is importable from the top-level namespace:
+
+```python
+import vardax as vdx
+
+model = vdx.ThreeDVar(...)
+step = model.as_analysis_step()
+```
+
+Three public submodules are also bound into the package namespace for the
+access patterns used in the design docs — `vdx.amortized.AmortizedPosterior`,
+`vdx.cycle.VarDACycle`, and `vdx.adjoints.OneStepAdjoint` resolve after a
+plain `import vardax`. Everything under `vardax._src` is private;
+import paths there may change without notice.
+
+## Division of labour
+
+vardax deliberately implements only the variational-DA layer:
+
+- **Linear algebra delegates to [gaussx](https://jejjohnson.github.io/gaussx/).**
+  Covariances are lazy lineax operators; inverses, diagonals, and ensemble
+  covariances route through `gaussx.inv`, `gaussx.diag`, and
+  `gaussx.ensemble_covariance` rather than being materialised here.
+- **Orchestration delegates to [pipekit-cycle](https://github.com/jejjohnson/pipekit).**
+  Every model exposes `.as_analysis_step()`, returning an object that
+  satisfies the pipekit `AnalysisStep` Protocol, and the
+  [Cycle Integration](cycle.md) factories wire whole assimilation cycles
+  together.

--- a/docs/api/models.md
+++ b/docs/api/models.md
@@ -1,0 +1,50 @@
+# Models
+
+The seven analysis methods are *peers* — sibling `equinox.Module` classes
+with no inheritance between them, each owning exactly the assumptions its
+math requires. Pick by problem structure: a single analysis time with a
+linear observation operator wants [OI](../04_oi_blue.md) or
+[3DVar](../05_threedvar.md); an assimilation window with perfect-model
+dynamics wants [strong-constraint 4DVar](../06_strong_4dvar.md); admitting
+model error turns that into [weak-constraint 4DVar](../07_weak_4dvar.md);
+the operational linearise-and-iterate formulation with control-variable
+transform is [incremental 4DVar](../08_incremental_4dvar.md); and replacing
+the inner-loop optimiser with a trained ConvLSTM gives
+[4DVarNet](../09_4dvarnet.md).
+
+Every model exposes `.as_analysis_step()`, returning a lightweight wrapper
+that satisfies the pipekit-cycle [`AnalysisStep`](protocols.md) Protocol —
+that is the seam through which all seven plug into
+[`VarDACycle` / `VarSmootherCycle`](cycle.md) interchangeably.
+
+## Classical methods
+
+Closed-form and optimisation-based analyses. `OptimalInterpolation` is the
+linear-Gaussian BLUE solution and refuses non-linear observation operators
+at construction; `ThreeDVar` minimises the same cost iteratively and accepts
+non-linear operators; the three 4DVar variants extend the cost over a time
+window. `IncrementalConfig` collects the outer/inner-loop knobs of
+`IncrementalFourDVar`.
+
+::: vardax
+    options:
+      show_root_heading: false
+      show_root_toc_entry: false
+      members: [OptimalInterpolation, ThreeDVar, StrongFourDVar, WeakFourDVar, IncrementalFourDVar, IncrementalConfig]
+
+## Learned solvers — 4DVarNet
+
+End-to-end-trainable 4DVar: the variational cost is kept explicit, but the
+inner-loop descent direction is produced by a ConvLSTM
+[gradient modulator](training.md) instead of a hand-tuned optimiser. The 1D
+variant operates on `Batch1D` (e.g. Lorenz-96 trajectories); the 2D variant
+on `Batch2D` / `Batch2DMultivar` fields (e.g. SSH reconstruction). The
+inner-loop iteration functions live on the
+[Costs, Priors & Solvers](costs_priors.md) page; training utilities on
+[Training & Adjoints](training.md).
+
+::: vardax
+    options:
+      show_root_heading: false
+      show_root_toc_entry: false
+      members: [FourDVarNet1D, FourDVarNet2D]

--- a/docs/api/obs_operators.md
+++ b/docs/api/obs_operators.md
@@ -1,0 +1,37 @@
+# Observation Operators
+
+Observation operators map model state to observation space. All of them
+satisfy the pipekit-cycle
+[`ObservationOperator`](protocols.md) Protocol — `__call__(state)` produces
+the predicted observation, and `linearize(state)` returns the tangent-linear
+(Jacobian) operator that the incremental and posterior-covariance machinery
+needs. Because conformance is structural, custom operators plug in by
+matching that signature; nothing here needs to be subclassed. See
+[Observation Operators](../11_observation_operators.md) in the Mathematical
+Reference for the modelling background.
+
+## Core operators
+
+`LinearObs` wraps an explicit observation matrix; `MaskedIdentity` handles
+the ubiquitous "observe a subset of grid points" case (satellite tracks,
+sparse sensor networks); `AveragingKernel` implements the smoothing kernels
+of retrieval products such as atmospheric-composition column averages.
+
+::: vardax
+    options:
+      show_root_heading: false
+      show_root_toc_entry: false
+      members: [LinearObs, MaskedIdentity, AveragingKernel]
+
+## Multi-instrument fusion
+
+Assimilating several instruments at once: each instrument is described by an
+`InstrumentSpec`, registered in an `InstrumentRegistry`, and
+`MultiInstrumentFusion` stacks the per-instrument operators into a single
+observation operator over the concatenated observation vector.
+
+::: vardax
+    options:
+      show_root_heading: false
+      show_root_toc_entry: false
+      members: [InstrumentSpec, InstrumentRegistry, MultiInstrumentFusion]

--- a/docs/api/posterior.md
+++ b/docs/api/posterior.md
@@ -1,0 +1,45 @@
+# Posterior Covariance
+
+A variational analysis returns a point estimate; this layer attaches the
+uncertainty around it. The design is deliberately *lazy and matrix-free*:
+a posterior adapter never materialises the covariance matrix. Instead it
+builds a lineax operator for the Hessian (or precision) at the analysis
+point, and inverses, diagonals (pointwise variances), and ensemble
+estimates are delegated to
+[gaussx](https://jejjohnson.github.io/gaussx/) — `gaussx.inv`,
+`gaussx.diag`, and `gaussx.ensemble_covariance` — so structured and
+iterative solves come for free. See
+[Posterior Covariance](../13_posterior_covariance.md) in the Mathematical
+Reference for derivations and when each approximation is trustworthy.
+
+Adapters satisfy the [`PosteriorAdapter`](protocols.md) Protocol and all
+produce the same `Posterior` container, so downstream diagnostics (e.g. the
+[posterior-agreement gate](utils.md)) are adapter-agnostic. Choose
+`LaplaceCovariance` for the exact-Hessian Gaussian approximation around the
+mode, `GaussNewtonHessian` when second derivatives of the observation
+operator are unavailable or noisy, and `EnsembleCovariance` when samples
+are cheaper than curvature.
+
+## Container
+
+::: vardax
+    options:
+      show_root_heading: false
+      show_root_toc_entry: false
+      members: [Posterior]
+
+## Adapters
+
+::: vardax
+    options:
+      show_root_heading: false
+      show_root_toc_entry: false
+      members: [LaplaceCovariance, GaussNewtonHessian, EnsembleCovariance]
+
+## Likelihoods
+
+::: vardax
+    options:
+      show_root_heading: false
+      show_root_toc_entry: false
+      members: [GaussianMarkLikelihood]

--- a/docs/api/protocols.md
+++ b/docs/api/protocols.md
@@ -1,0 +1,50 @@
+# Protocols & Types
+
+vardax components are coupled structurally: anything with the right
+methods conforms, with no base class to inherit. Three of the Protocols —
+`AnalysisStep`, `ForwardModel`, and `ObservationOperator` — are re-exported
+from [pipekit-cycle](https://github.com/jejjohnson/pipekit) and define the
+seam along which vardax plugs into assimilation
+[cycles](cycle.md); the rest are vardax-specific and define the seams
+*inside* a variational method (prior, cost, gradient modulator, posterior
+adapter, minimiser). All are runtime-checkable, so `isinstance` checks work
+at the boundaries.
+
+## pipekit-cycle protocols
+
+The orchestration contract. `ForwardModel` propagates state between cycle
+times, `ObservationOperator` maps state to observation space (with
+`linearize` for the tangent-linear), and `AnalysisStep` is what every
+vardax model's `.as_analysis_step()` returns.
+
+::: vardax
+    options:
+      show_root_heading: false
+      show_root_toc_entry: false
+      members: [AnalysisStep, ForwardModel, ObservationOperator]
+
+## vardax protocols
+
+The internal seams: implement these to swap in custom
+[priors](costs_priors.md), cost functions,
+[gradient modulators](training.md),
+[posterior adapters](posterior.md), or inner-loop minimisers without
+touching the model classes.
+
+::: vardax
+    options:
+      show_root_heading: false
+      show_root_toc_entry: false
+      members: [Prior, CostFunction, GradModulator, PosteriorAdapter, Minimiser]
+
+## Batch & state types
+
+The typed carriers that flow through the solvers and training loops:
+1D and 2D (single- and multi-variable) observation batches, and the
+recurrent-state containers of the ConvLSTM gradient modulators.
+
+::: vardax
+    options:
+      show_root_heading: false
+      show_root_toc_entry: false
+      members: [Batch1D, Batch2D, Batch2DMultivar, LSTMState1D, LSTMState2D]

--- a/docs/api/training.md
+++ b/docs/api/training.md
@@ -1,0 +1,70 @@
+# Training & Adjoints
+
+Training a learned solver means differentiating *through* an inner
+optimisation loop, and how you do that determines memory cost and gradient
+quality. The adjoint strategies here make that choice explicit and
+swappable — see [Adjoint Methods](../12_adjoint_methods.md) in the
+Mathematical Reference for the trade-offs. Around them sit the loss
+functions and train/eval steps for [4DVarNet](models.md) and the
+[amortized posteriors](amortized.md), and the ConvLSTM gradient modulators
+that 4DVarNet learns in place of a hand-tuned inner optimiser.
+
+## Adjoint strategies
+
+Implementations of `vardax.adjoints` (Decision D15): full
+backpropagation with checkpointed memory (`RecursiveCheckpointAdjoint`),
+truncated one-step gradients (`OneStepAdjoint`, pairing with the
+`one_step_solve_*` [solver functions](costs_priors.md)), and
+implicit differentiation at a fixed point (`ImplicitAdjoint`, pairing with
+`solve_4dvarnet_1d_fixedpoint`). All three are also accessible via the
+`vardax.adjoints` submodule namespace. Use
+[`assert_adjoint_calibrated`](utils.md) to verify a cheap adjoint against
+the exact one before trusting it.
+
+`RecursiveCheckpointAdjoint` and `ImplicitAdjoint` are re-exported from
+[optimistix](https://docs.kidger.site/optimistix/) for one-stop import;
+see the optimistix documentation for their full signatures:
+
+- `vardax.RecursiveCheckpointAdjoint` —
+  [`optimistix.RecursiveCheckpointAdjoint`](https://docs.kidger.site/optimistix/api/adjoints/),
+  exact reverse-mode backpropagation through the unrolled inner loop with
+  binomial checkpointing (the default).
+- `vardax.ImplicitAdjoint` —
+  [`optimistix.ImplicitAdjoint`](https://docs.kidger.site/optimistix/api/adjoints/),
+  implicit-function-theorem differentiation at a fixed point; pair with
+  `solve_4dvarnet_1d_fixedpoint`.
+
+`OneStepAdjoint` is vardax's own truncated adjoint (Bolte, Pauwels &
+Vaiter, NeurIPS 2023):
+
+::: vardax
+    options:
+      show_root_heading: false
+      show_root_toc_entry: false
+      members: [OneStepAdjoint]
+
+## Gradient modulators
+
+The learned components of 4DVarNet: ConvLSTM cells that map the raw
+variational-cost gradient to a descent update, satisfying the
+[`GradModulator`](protocols.md) Protocol. Their recurrent state is carried
+in the [`LSTMState1D` / `LSTMState2D`](protocols.md) containers.
+
+::: vardax
+    options:
+      show_root_heading: false
+      show_root_toc_entry: false
+      members: [ConvLSTMGradMod1D, ConvLSTMGradMod2D]
+
+## Losses & steps
+
+Outer-loop training: reconstruction-based losses for 4DVarNet, the
+negative-log-likelihood loss for amortized posteriors, and the
+optax-driven `train_step` / `amortized_train_step` / `eval_step` that
+consume them.
+
+::: vardax
+    options:
+      show_root_heading: false
+      show_root_toc_entry: false
+      members: [reconstruction_loss, train_loss_fn, train_step, eval_step, amortized_nll_loss_fn, amortized_train_step]

--- a/docs/api/utils.md
+++ b/docs/api/utils.md
@@ -1,0 +1,42 @@
+# Utilities & Diagnostics
+
+Supporting cast: a reference dynamical system for experiments, the
+statistical gates that decide whether an inference setup can be trusted,
+and the plotting helpers used throughout the
+[end-to-end examples](../15_lorenz_examples.md).
+
+## Dynamical systems
+
+Lorenz-96 is the standard chaotic testbed for assimilation experiments;
+`simulate_lorenz96` generates trajectories for the
+[Lorenz examples](../15_lorenz_examples.md) and the test suite.
+
+::: vardax
+    options:
+      show_root_heading: false
+      show_root_toc_entry: false
+      members: [simulate_lorenz96]
+
+## Validation gates
+
+The six-step methodology's go/no-go checks (Decision D12):
+simulation-based calibration ranks the truth within posterior samples and
+must be uniform; `assert_posterior_agreement` cross-checks two
+[posterior adapters](posterior.md) against each other; and
+`assert_adjoint_calibrated` verifies that a cheap
+[adjoint](training.md) tracks the exact gradient before it is used for
+training. Run these before believing any uncertainty estimate.
+
+::: vardax
+    options:
+      show_root_heading: false
+      show_root_toc_entry: false
+      members: [simulation_based_calibration, assert_posterior_agreement, assert_adjoint_calibrated]
+
+## Visualization
+
+::: vardax
+    options:
+      show_root_heading: false
+      show_root_toc_entry: false
+      members: [plot_l96_trajectories, plot_l96_grid, plot_reconstruction_comparison]

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -42,20 +42,40 @@ plugins:
       handlers:
         python:
           paths:
-            - .
+            - src
           options:
-            docstring_style: numpy
+            preload_modules: [pipekit_cycle]
+            docstring_style: google
+            docstring_section_style: table
             show_source: true
             show_root_heading: true
-            show_signature_annotations: true
-            separate_signature: true
+            show_root_full_path: false
+            show_symbol_type_heading: true
+            show_symbol_type_toc: true
             members_order: source
+            heading_level: 3
+            show_signature_annotations: true
+            signature_crossrefs: true
+            separate_signature: true
+            merge_init_into_class: false
+            filters: ["!^_"]
   - mkdocs-jupyter:
       execute: false
       ignore_h1_titles: true
 
 nav:
   - Home: index.md
+  - API Reference:
+      - Overview: api/index.md
+      - Models: api/models.md
+      - Amortized Inference: api/amortized.md
+      - Observation Operators: api/obs_operators.md
+      - Posterior Covariance: api/posterior.md
+      - Costs, Priors & Solvers: api/costs_priors.md
+      - Training & Adjoints: api/training.md
+      - Cycle Integration: api/cycle.md
+      - Protocols & Types: api/protocols.md
+      - Utilities & Diagnostics: api/utils.md
   - Mathematical Reference:
       - Foundation:
           - 1. Problem Setting: 01_problem_setting.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,6 +101,8 @@ packages = ["src/vardax"]
 [dependency-groups]
 test = [
     "pytest>=8.0.0",
+    # tests/test_docstrings.py parses docstrings the way mkdocstrings does.
+    "griffe>=1.0",
     "pytest-cov>=5.0.0",
     "pytest-pretty>=1.2.0",
     "pytest-xdist>=3.5.0",

--- a/src/vardax/__init__.py
+++ b/src/vardax/__init__.py
@@ -1,15 +1,13 @@
 """vardax — Modular variational data assimilation with learned components.
 
-Public API
-----------
 All public symbols are re-exported from the private ``_src`` subpackage so
 that user code imports from the top-level namespace:
 
-.. code-block:: python
+```python
+import vardax
 
-    import vardax
-
-    model = vardax.FourDVarNet1D(...)
+model = vardax.FourDVarNet1D(...)
+```
 """
 
 # Bind public submodules into the ``vardax`` namespace so the

--- a/src/vardax/_src/adapters/pipekit_train.py
+++ b/src/vardax/_src/adapters/pipekit_train.py
@@ -4,26 +4,25 @@ Provides minimal glue so a vardax model + a ``pipekit_train.Loss``
 implementation compose into a ``pipekit_train.TrainingLoop`` without
 the user reimplementing the inner training step.
 
-Usage
------
+Typical usage:
 
-.. code-block:: python
+```python
+from pipekit_jax import JaxModelOp
+from pipekit_train import MSE, EarlyStopping, Checkpoint, TrainingLoop
+from vardax import FourDVarNet1D
+from vardax.adapters.pipekit_train import VardaxReconLoss
 
-    from pipekit_jax import JaxModelOp
-    from pipekit_train import MSE, EarlyStopping, Checkpoint, TrainingLoop
-    from vardax import FourDVarNet1D
-    from vardax.adapters.pipekit_train import VardaxReconLoss
+model = FourDVarNet1D(state_dim=N, n_time=T, ..., key=key)
+model_op = JaxModelOp(model)
 
-    model = FourDVarNet1D(state_dim=N, n_time=T, ..., key=key)
-    model_op = JaxModelOp(model)
-
-    loop = TrainingLoop(
-        dataset=my_dataset,
-        model_op=model_op,
-        loss=VardaxReconLoss(),     # equiv to pipekit_train.MSE on (model(batch), batch.target)
-        callbacks=[EarlyStopping(patience=10), Checkpoint(registry, every_n=100)],
-    )
-    trained_op, state = loop(model_op, TrainerCarryState(...))
+loop = TrainingLoop(
+    dataset=my_dataset,
+    model_op=model_op,
+    loss=VardaxReconLoss(),  # pipekit_train.MSE on (model(batch), batch.target)
+    callbacks=[EarlyStopping(patience=10), Checkpoint(registry, every_n=100)],
+)
+trained_op, state = loop(model_op, TrainerCarryState(...))
+```
 
 The adapter is intentionally thin — ``pipekit_train.MSE()`` already
 works for the standard reconstruction-loss case. ``VardaxReconLoss``

--- a/src/vardax/_src/adjoints/__init__.py
+++ b/src/vardax/_src/adjoints/__init__.py
@@ -4,31 +4,31 @@ vardax does not own adjoint code. Gradients through the inner learned
 solver are composed by selecting an ``optimistix.AbstractAdjoint`` on
 the model:
 
-.. code-block:: python
+```python
+import optimistix as optx
+from vardax.adjoints import OneStepAdjoint
 
-    import optimistix as optx
-    from vardax.adjoints import OneStepAdjoint
-
-    model = FourDVarNet1D(
-        ...,
-        solver_adjoint=OneStepAdjoint(),  # O(1) memory, Bolte 2023
-    )
-    model = FourDVarNet1D(
-        ...,
-        solver_adjoint=optx.RecursiveCheckpointAdjoint(),  # default
-    )
-    model = FourDVarNet1D(
-        ...,
-        solver_adjoint=optx.ImplicitAdjoint(),  # IFT at fixed point
-    )
+model = FourDVarNet1D(
+    ...,
+    solver_adjoint=OneStepAdjoint(),  # O(1) memory, Bolte 2023
+)
+model = FourDVarNet1D(
+    ...,
+    solver_adjoint=optx.RecursiveCheckpointAdjoint(),  # default
+)
+model = FourDVarNet1D(
+    ...,
+    solver_adjoint=optx.ImplicitAdjoint(),  # IFT at fixed point
+)
+```
 
 The choice replaces the v0.3 ``grad_mode: Literal["unrolled",
 "one_step", "implicit"]`` enum (dropped in this epic, Decision D15).
 
 This module ships:
 
-- :class:`OneStepAdjoint` — Bolte, Pauwels & Vaiter (NeurIPS 2023);
-  the only vardax-owned adjoint. Subclasses
+- [`OneStepAdjoint`][vardax.OneStepAdjoint] — Bolte, Pauwels & Vaiter
+  (NeurIPS 2023); the only vardax-owned adjoint. Subclasses
   ``optimistix.AbstractAdjoint`` and targets upstream contribution.
 - Re-exports ``optimistix.RecursiveCheckpointAdjoint`` and
   ``optimistix.ImplicitAdjoint`` for one-stop import.

--- a/src/vardax/_src/adjoints/one_step.py
+++ b/src/vardax/_src/adjoints/one_step.py
@@ -42,23 +42,24 @@ class OneStepAdjoint(optx.AbstractAdjoint):
     O(1) memory and is exact at the fixed point of the inner
     iteration.
 
-    Use as the ``solver_adjoint`` argument to ``FourDVarNet1D`` /
-    ``FourDVarNet2D``:
+    Use as the ``solver_adjoint`` argument to
+    [`FourDVarNet1D`][vardax.FourDVarNet1D] /
+    [`FourDVarNet2D`][vardax.FourDVarNet2D]:
 
-    .. code-block:: python
+    ```python
+    from vardax.adjoints import OneStepAdjoint
 
-        from vardax.adjoints import OneStepAdjoint
-
-        model = FourDVarNet1D(
-            state_dim=N, n_time=T, ...,
-            solver_adjoint=OneStepAdjoint(),
-            key=key,
-        )
+    model = FourDVarNet1D(
+        state_dim=N, n_time=T, ...,
+        solver_adjoint=OneStepAdjoint(),
+        key=key,
+    )
+    ```
 
     References:
         Bolte, J., Pauwels, E. & Vaiter, S. (2023). One-step
         differentiation of iterative algorithms. NeurIPS 36.
-        `arXiv:2305.13768 <https://arxiv.org/abs/2305.13768>`_.
+        [arXiv:2305.13768](https://arxiv.org/abs/2305.13768).
     """
 
     def apply(

--- a/src/vardax/_src/amortized/__init__.py
+++ b/src/vardax/_src/amortized/__init__.py
@@ -1,9 +1,9 @@
-"""Amortized inference (Epic 8 / Decision D12).
+r"""Amortized inference (Epic 8 / Decision D12).
 
-Learns a conditional density :math:`q_\\phi(x \\mid y)` that maps
+Learns a conditional density $q_\phi(x \mid y)$ that maps
 observations directly to posteriors. Trained by simulation: sample
-:math:`x \\sim p(x)`, simulate :math:`y \\mid x`, train
-:math:`q_\\phi` to recover :math:`x` from :math:`y`. Per-event inference
+$x \sim p(x)$, simulate $y \mid x$, train
+$q_\phi$ to recover $x$ from $y$. Per-event inference
 is a single forward pass — the cost amortises over many events.
 
 Three head choices via ``AmortizedConfig.head_type``:

--- a/src/vardax/_src/amortized/posterior.py
+++ b/src/vardax/_src/amortized/posterior.py
@@ -3,29 +3,29 @@
 Composes an encoder (``(input, mask) → context``) with a density head
 (``context → q_φ(x | y)``). Trained by simulation:
 
-.. code-block:: python
+```python
+def sample_train_pair(key):
+    x = prior_distribution.sample(key)
+    y = forward_model(x) + obs_noise.sample(key)
+    return Batch1D(input=y, mask=quality_mask, target=x)
 
-    def sample_train_pair(key):
-        x = prior_distribution.sample(key)
-        y = forward_model(x) + obs_noise.sample(key)
-        return Batch1D(input=y, mask=quality_mask, target=x)
 
-
-    for batch in simulation_loader:
-        model, opt_state, loss = amortized_train_step(
-            model,
-            batch,
-            optimizer,
-            opt_state,
-        )
+for batch in simulation_loader:
+    model, opt_state, loss = amortized_train_step(
+        model,
+        batch,
+        optimizer,
+        opt_state,
+    )
+```
 
 Inference (sub-second):
 
-.. code-block:: python
-
-    x_map = model(batch)  # MAP / mode
-    samples = model.sample(batch, key, n=200)  # posterior samples
-    log_p = model.log_prob(x, batch)  # exact for flow/regression
+```python
+x_map = model(batch)  # MAP / mode
+samples = model.sample(batch, key, n=200)  # posterior samples
+log_p = model.log_prob(x, batch)  # exact for flow/regression
+```
 """
 
 from __future__ import annotations
@@ -43,7 +43,7 @@ from .config import AmortizedConfig
 
 
 class AmortizedPosterior(eqx.Module):
-    """Amortized variational posterior :math:`q_\\phi(x \\mid y)`.
+    r"""Amortized variational posterior $q_\phi(x \mid y)$.
 
     Attributes:
         encoder: ``eqx.Module`` mapping ``(input, mask)`` to a context
@@ -60,7 +60,7 @@ class AmortizedPosterior(eqx.Module):
     config: AmortizedConfig
 
     def __call__(self, batch: Batch1D | Batch2D) -> Float[Array, ...]:
-        """Return the per-sample MAP / mode of :math:`q_\\phi(x \\mid y)`."""
+        r"""Return the per-sample MAP / mode of $q_\phi(x \mid y)$."""
 
         def _one(input_i, mask_i):
             ctx = self.encoder(input_i, mask_i)

--- a/src/vardax/_src/costs.py
+++ b/src/vardax/_src/costs.py
@@ -17,15 +17,15 @@ def obs_cost_1d(
     obs: Float[Array, "B T N"],
     mask: Float[Array, "B T N"],
 ) -> Float[Array, ""]:
-    """Observation cost for 1-D data.
+    r"""Observation cost for 1-D data.
 
     Computes the masked mean-squared error between the state and observations:
 
-    .. math::
+    $$
+    J_{obs} = \frac{1}{|\Omega|} \sum_{i \in \Omega} (x_i - y_i)^2
+    $$
 
-        J_{obs} = \\frac{1}{|\\Omega|} \\sum_{i \\in \\Omega} (x_i - y_i)^2
-
-    where :math:`\\Omega` is the set of observed locations (``mask == 1``).
+    where $\Omega$ is the set of observed locations (``mask == 1``).
 
     Args:
         state: Current state estimate of shape ``(B, T, N)``.
@@ -35,6 +35,15 @@ def obs_cost_1d(
 
     Returns:
         Scalar observation cost.
+
+    Examples:
+        >>> import jax.numpy as jnp
+        >>> from vardax import obs_cost_1d
+        >>> state = jnp.ones((1, 1, 4))
+        >>> obs = jnp.zeros((1, 1, 4))
+        >>> mask = jnp.ones((1, 1, 4))
+        >>> float(obs_cost_1d(state, obs, mask))
+        1.0
     """
     diff = mask * (state - obs)
     return jnp.mean(diff**2)
@@ -45,15 +54,15 @@ def obs_cost_2d(
     obs: Float[Array, "B T H W"],
     mask: Float[Array, "B T H W"],
 ) -> Float[Array, ""]:
-    """Observation cost for 2-D data.
+    r"""Observation cost for 2-D data.
 
     Computes the masked mean-squared error between the state and observations:
 
-    .. math::
+    $$
+    J_{obs} = \frac{1}{|\Omega|} \sum_{i \in \Omega} (x_i - y_i)^2
+    $$
 
-        J_{obs} = \\frac{1}{|\\Omega|} \\sum_{i \\in \\Omega} (x_i - y_i)^2
-
-    where :math:`\\Omega` is the set of observed locations (``mask == 1``).
+    where $\Omega$ is the set of observed locations (``mask == 1``).
 
     Args:
         state: Current state estimate of shape ``(B, T, H, W)``.
@@ -71,14 +80,14 @@ def prior_cost(
     state: Float[Array, ...],
     prior_reconstruction: Float[Array, ...],
 ) -> Float[Array, ""]:
-    """Prior cost based on learned autoencoder reconstruction.
+    r"""Prior cost based on learned autoencoder reconstruction.
 
     Computes the mean-squared error between the state and its reconstruction
     through the learned prior (autoencoder):
 
-    .. math::
-
-        J_{prior} = \\|x - \\varphi(x)\\|^2
+    $$
+    J_{prior} = \|x - \varphi(x)\|^2
+    $$
 
     Args:
         state: Current state estimate of arbitrary shape.
@@ -103,12 +112,12 @@ def variational_cost(
     alpha_obs: float = 0.5,
     alpha_prior: float = 0.5,
 ) -> Float[Array, ""]:
-    """Compute the variational cost :math:`U(x)`.
+    r"""Compute the variational cost $U(x)$.
 
-    .. math::
-
-        U(x) = \\alpha_{obs} \\|m \\odot (x - y)\\|^2
-              + \\alpha_{prior} \\|x - \\varphi(x)\\|^2
+    $$
+    U(x) = \alpha_{obs} \|m \odot (x - y)\|^2
+          + \alpha_{prior} \|x - \varphi(x)\|^2
+    $$
 
     Args:
         x: Current state estimate.
@@ -120,6 +129,16 @@ def variational_cost(
 
     Returns:
         Scalar cost value.
+
+    Examples:
+        With the trivial [`IdentityPrior`][vardax.IdentityPrior] the
+        prior term vanishes, leaving the weighted observation MSE.
+
+        >>> import jax.numpy as jnp, vardax
+        >>> batch = vardax.Batch1D(input=jnp.zeros((1, 2, 4)), mask=jnp.ones((1, 2, 4)))
+        >>> x = jnp.ones((1, 2, 4))
+        >>> float(vardax.variational_cost(x, batch, vardax.IdentityPrior()))
+        0.5
     """
     obs_diff = batch.mask * (x - batch.input)
     j_obs = jnp.mean(obs_diff**2)
@@ -134,7 +153,7 @@ def variational_cost_grad(
     alpha_obs: float = 0.5,
     alpha_prior: float = 0.5,
 ) -> Float[Array, ...]:
-    """Return the gradient of :func:`variational_cost` with respect to ``x``.
+    """Gradient of [`variational_cost`][vardax.variational_cost] w.r.t. ``x``.
 
     Args:
         x: Current state estimate.

--- a/src/vardax/_src/cycle/da_cycle.py
+++ b/src/vardax/_src/cycle/da_cycle.py
@@ -5,16 +5,19 @@ Per Decision D8, vardax models satisfy ``pipekit_cycle.AnalysisStep`` via
 vardax model (any of the seven Layer 2 classes) plus a forward and obs
 operator, and return a configured pipekit-cycle object ready to call.
 
-Examples:
+Typical operational wiring:
 
-    >>> import vardax as vdx
-    >>> cycle = vdx.cycle.VarDACycle(
-    ...     forward=somax_model,
-    ...     obs_op=vdx.obs_operators.MaskedIdentity(),
-    ...     model=vdx.IncrementalFourDVar(...),
-    ...     n_steps=24,
-    ... )
-    >>> analysis, state = cycle(initial_state, vdx.cycle.DAState())
+```python
+import vardax as vdx
+
+cycle = vdx.cycle.VarDACycle(
+    forward=somax_model,
+    obs_op=vdx.MaskedIdentity(),
+    model=vdx.IncrementalFourDVar(...),
+    n_steps=24,
+)
+analysis, state = cycle(initial_state, da_state)
+```
 """
 
 from __future__ import annotations
@@ -69,6 +72,32 @@ def VarDACycle(
     Raises:
         AttributeError: If ``model`` does not expose
             ``.as_analysis_step()``.
+
+    Examples:
+        >>> import equinox as eqx
+        >>> import jax, jax.numpy as jnp, lineax as lx
+        >>> import vardax as vdx
+        >>> class IdentityForward(eqx.Module):
+        ...     dt: float = 1.0
+        ...     state_signature: None = None
+        ...
+        ...     def step(self, state, dt):
+        ...         return state
+        >>> eye = lx.IdentityLinearOperator(jax.ShapeDtypeStruct((1, 4), jnp.float32))
+        >>> oi = vdx.OptimalInterpolation(
+        ...     obs_op=vdx.LinearObs(H_mat=eye),
+        ...     prior_mean=jnp.zeros((1, 4)),
+        ...     prior_cov_op=eye,
+        ...     obs_cov_op=eye,
+        ... )
+        >>> cycle = vdx.VarDACycle(
+        ...     forward=IdentityForward(),
+        ...     obs_op=vdx.MaskedIdentity(),
+        ...     model=oi,
+        ...     n_steps=1,
+        ... )
+        >>> type(cycle).__name__
+        'DACycle'
     """
     if not hasattr(model, "as_analysis_step"):
         raise AttributeError(

--- a/src/vardax/_src/model.py
+++ b/src/vardax/_src/model.py
@@ -39,13 +39,13 @@ def _default_adjoint() -> optx.AbstractAdjoint:
 
 
 class FourDVarNet1D(eqx.Module):
-    """End-to-end 4DVarNet model for 1-D spatiotemporal reconstruction.
+    r"""End-to-end 4DVarNet model for 1-D spatiotemporal reconstruction.
 
     Minimises the variational cost
 
-    .. math::
-
-        J(x) = \\|\\mathbf{m} \\odot (x - y)\\|^2 + \\lambda \\|x - \\varphi(x)\\|^2
+    $$
+    J(x) = \|\mathbf{m} \odot (x - y)\|^2 + \lambda \|x - \varphi(x)\|^2
+    $$
 
     using ``n_solver_steps`` learned gradient steps modulated by a ConvLSTM,
     with the differentiation strategy selected by ``solver_adjoint``.
@@ -53,7 +53,7 @@ class FourDVarNet1D(eqx.Module):
     Attributes:
         n_solver_steps: Number of solver iterations to unroll.
         alpha: Gradient step-size.
-        prior_weight: Weight :math:`\\lambda` for the prior cost term.
+        prior_weight: Weight $\lambda$ for the prior cost term.
         solver_adjoint: ``optimistix.AbstractAdjoint`` selecting the
             differentiation strategy. Defaults to
             ``RecursiveCheckpointAdjoint`` (standard backprop). Use

--- a/src/vardax/_src/models/__init__.py
+++ b/src/vardax/_src/models/__init__.py
@@ -5,10 +5,13 @@ All implement ``pipekit_cycle.AnalysisStep`` via ``.as_analysis_step()``.
 
 Classical methods:
 
-- :class:`OptimalInterpolation` — BLUE / OI, closed-form linear-Gaussian
-- :class:`ThreeDVar`            — 3DVar, nonlinear H, single time
-- :class:`StrongFourDVar`       — strong-constraint 4DVar, control = x_0
-- :class:`WeakFourDVar`         — weak-constraint 4DVar, control = (x_0, η)
+- [`OptimalInterpolation`][vardax.OptimalInterpolation] — BLUE / OI,
+  closed-form linear-Gaussian
+- [`ThreeDVar`][vardax.ThreeDVar] — 3DVar, nonlinear H, single time
+- [`StrongFourDVar`][vardax.StrongFourDVar] — strong-constraint 4DVar,
+  control = x_0
+- [`WeakFourDVar`][vardax.WeakFourDVar] — weak-constraint 4DVar,
+  control = (x_0, η)
 
 Learned methods live alongside in ``vardax._src.model`` (the
 ``FourDVarNet*`` classes). They satisfy the same protocol contract.

--- a/src/vardax/_src/models/incremental_fourdvar.py
+++ b/src/vardax/_src/models/incremental_fourdvar.py
@@ -1,21 +1,22 @@
-"""Incremental 4DVar with control-variable transform (Decision D11).
+r"""Incremental 4DVar with control-variable transform (Decision D11).
 
-The operational fast path of ``StrongFourDVar``: Gauss-Newton outer
-iterations on the full nonlinear cost, CG inner iterations on the
-linearised quadratic subproblem, with a control-variable transform
-:math:`\\chi = B^{-1/2}(\\delta x)` for preconditioning.
+The operational fast path of [`StrongFourDVar`][vardax.StrongFourDVar]:
+Gauss-Newton outer iterations on the full nonlinear cost, CG inner
+iterations on the linearised quadratic subproblem, with a
+control-variable transform $\chi = B^{-1/2}(\delta x)$ for
+preconditioning.
 
-At each outer iteration around :math:`x_b^{(k)}`:
+At each outer iteration around $x_b^{(k)}$:
 
-1. Linearise :math:`M_t` and :math:`H_t` (via ``jax.linearize``).
+1. Linearise $M_t$ and $H_t$ (via ``jax.linearize``).
 2. Form the Gauss-Newton Hessian
-   :math:`J''_{GN} = B^{-1} + \\sum_t (H'_t M'_t)^\\top R_t^{-1} (H'_t M'_t)`.
-3. Solve :math:`J''_{GN}\\,\\delta x^* = \\text{rhs}` via lineax CG
-   (in :math:`\\chi`-space if CVT enabled).
-4. Update :math:`x_b^{(k+1)} = x_b^{(k)} + \\delta x^*`.
+   $J''_{GN} = B^{-1} + \sum_t (H'_t M'_t)^\top R_t^{-1} (H'_t M'_t)$.
+3. Solve $J''_{GN}\,\delta x^* = \text{rhs}$ via lineax CG
+   (in $\chi$-space if CVT enabled).
+4. Update $x_b^{(k+1)} = x_b^{(k)} + \delta x^*$.
 
 This implementation uses ``lineax.JacobianLinearOperator`` for
-:math:`M'_t`, :math:`H'_t` (autodiff-derived) and ``lineax.CG``
+$M'_t$, $H'_t$ (autodiff-derived) and ``lineax.CG``
 with positive-semidefinite tagging for the inner solve. The CVT is
 applied via ``gaussx.sqrt`` when ``cvt=True`` — gaussx returns the
 square-root operator for any positive-definite operator (Cholesky
@@ -53,20 +54,47 @@ class IncrementalConfig(eqx.Module):
 
 
 class IncrementalFourDVar(eqx.Module):
-    """Operational incremental 4DVar (Decision D11).
+    r"""Operational incremental 4DVar (Decision D11).
 
-    Functionally equivalent to ``StrongFourDVar`` (same problem, same
-    answer in the converged limit) but with a specialised inner
-    solver: Gauss-Newton outer iterations and CG inner iterations on
-    the linearised cost. Use this for production / long-window 4DVar.
+    Functionally equivalent to [`StrongFourDVar`][vardax.StrongFourDVar]
+    (same problem, same answer in the converged limit) but with a
+    specialised inner solver: Gauss-Newton outer iterations and CG
+    inner iterations on the linearised cost. Use this for production /
+    long-window 4DVar.
 
     Attributes:
         forward: ``pipekit_cycle.ForwardModel``.
         obs_op: Observation operator.
-        prior_mean: Background :math:`x_b` — initial state ``(N,)``.
-        prior_cov_op: :math:`B`.
-        obs_cov_op: :math:`R`.
-        config: ``IncrementalConfig``.
+        prior_mean: Background $x_b$ — initial state ``(N,)``.
+        prior_cov_op: $B$.
+        obs_cov_op: $R$.
+        config: [`IncrementalConfig`][vardax.IncrementalConfig].
+
+    Examples:
+        Trivial dynamics ($M_t(x) = x$) and a single timestep reduce
+        the problem to 3DVar, so with $B = R = I$ the converged
+        analysis is $x_0^* = y / 2$.
+
+        >>> import jax, jax.numpy as jnp, lineax as lx, vardax
+        >>> class Identity:
+        ...     dt = 1.0
+        ...
+        ...     def step(self, x, dt):
+        ...         return x
+        >>> eye = lx.IdentityLinearOperator(jax.ShapeDtypeStruct((3,), jnp.float32))
+        >>> inc = vardax.IncrementalFourDVar(
+        ...     forward=Identity(),
+        ...     obs_op=vardax.MaskedIdentity(),
+        ...     prior_mean=jnp.zeros(3),
+        ...     prior_cov_op=eye,
+        ...     obs_cov_op=eye,
+        ... )
+        >>> batch = vardax.Batch1D(input=jnp.ones((1, 1, 3)), mask=jnp.ones((1, 1, 3)))
+        >>> xa = inc(batch)
+        >>> xa.shape
+        (1, 3)
+        >>> bool(jnp.allclose(xa, 0.5, atol=1e-2))
+        True
     """
 
     forward: Any

--- a/src/vardax/_src/models/optimal_interpolation.py
+++ b/src/vardax/_src/models/optimal_interpolation.py
@@ -1,21 +1,21 @@
-"""Optimal Interpolation / BLUE (Decision D16).
+r"""Optimal Interpolation / BLUE (Decision D16).
 
 Closed-form linear-Gaussian analysis: the Best Linear Unbiased
-Estimator. When :math:`H` is linear and :math:`B`, :math:`R` are
-Gaussian, the posterior is exact in one matrix expression — no
-iteration, no convergence criterion.
+Estimator. When $H$ is linear and $B$, $R$ are Gaussian, the
+posterior is exact in one matrix expression — no iteration, no
+convergence criterion.
 
-.. math::
-
-    x^* = x_b + K (y - H x_b), \\quad K = B H^\\top (H B H^\\top + R)^{-1}.
+$$
+x^* = x_b + K (y - H x_b), \quad K = B H^\top (H B H^\top + R)^{-1}.
+$$
 
 Implementation notes:
 
 - The inversion is solved by ``lineax.CG`` against an
-  ``AbstractLinearOperator``; we never materialise :math:`HBH^\\top + R`.
+  ``AbstractLinearOperator``; we never materialise $HBH^\top + R$.
 - ``B_op`` and ``R_op`` are supplied as ``lineax.AbstractLinearOperator``
   (typically ``gaussx`` structured operators for Matérn priors and
-  diagonal :math:`R`).
+  diagonal $R$).
 - The class refuses non-linear observation operators on construction.
 """
 
@@ -33,20 +33,40 @@ from vardax._src._types import Batch1D
 
 
 class OptimalInterpolation(eqx.Module):
-    """BLUE / OI — closed-form linear-Gaussian analysis.
+    r"""BLUE / OI — closed-form linear-Gaussian analysis.
 
     Attributes:
         obs_op: Observation operator. Must be linear (its
             ``linearize(x)`` must return an operator independent of
-            ``x``). Use ``ThreeDVar`` for non-linear ``H``.
-        prior_mean: Background :math:`x_b` of shape ``(T, N)``.
-        prior_cov_op: Background-error covariance :math:`B` as a
+            ``x``). Use [`ThreeDVar`][vardax.ThreeDVar] for non-linear
+            ``H``.
+        prior_mean: Background $x_b$ of shape ``(T, N)``.
+        prior_cov_op: Background-error covariance $B$ as a
             ``lineax.AbstractLinearOperator``.
-        obs_cov_op: Observation-error covariance :math:`R` as a
+        obs_cov_op: Observation-error covariance $R$ as a
             ``lineax.AbstractLinearOperator``.
         cg_atol: CG absolute tolerance for the inner solve.
         cg_rtol: CG relative tolerance for the inner solve.
         cg_max_steps: CG iteration cap.
+
+    Examples:
+        With $B = R = I$, identity $H$ and everything observed, the
+        analysis splits the innovation in half: $x^* = y / 2$.
+
+        >>> import jax, jax.numpy as jnp, lineax as lx, vardax
+        >>> eye = lx.IdentityLinearOperator(jax.ShapeDtypeStruct((1, 3), jnp.float32))
+        >>> oi = vardax.OptimalInterpolation(
+        ...     obs_op=vardax.MaskedIdentity(),
+        ...     prior_mean=jnp.zeros((1, 3)),
+        ...     prior_cov_op=eye,
+        ...     obs_cov_op=eye,
+        ... )
+        >>> batch = vardax.Batch1D(input=jnp.ones((1, 1, 3)), mask=jnp.ones((1, 1, 3)))
+        >>> xa = oi(batch)
+        >>> xa.shape
+        (1, 1, 3)
+        >>> bool(jnp.allclose(xa, 0.5, atol=1e-4))
+        True
     """
 
     obs_op: Any  # ObservationOperator (linear)

--- a/src/vardax/_src/models/strong_fourdvar.py
+++ b/src/vardax/_src/models/strong_fourdvar.py
@@ -1,15 +1,15 @@
-"""Strong-constraint 4DVar.
+r"""Strong-constraint 4DVar.
 
 Multi-time analysis with the control variable being the initial state
-:math:`x_0`. The forward model :math:`M_t` is treated as exact (no
-model-error term). Cost:
+$x_0$. The forward model $M_t$ is treated as exact (no model-error
+term). Cost:
 
-.. math::
+$$
+J(x_0) = \tfrac{1}{2} \|x_0 - x_b\|^2_{B^{-1}}
+       + \tfrac{1}{2} \sum_{t=0}^{T} \|y_t - H_t(M_t(x_0))\|^2_{R_t^{-1}}.
+$$
 
-    J(x_0) = \\tfrac{1}{2} \\|x_0 - x_b\\|^2_{B^{-1}}
-           + \\tfrac{1}{2} \\sum_{t=0}^{T} \\|y_t - H_t(M_t(x_0))\\|^2_{R_t^{-1}}.
-
-Gradients of :math:`J` w.r.t. :math:`x_0` flow through the rollout
+Gradients of $J$ w.r.t. $x_0$ flow through the rollout
 ``trajectory = [forward.step(x, dt) for _ in range(T)]`` and back —
 the adjoint composition is whatever JAX gives by default. For long
 windows where the forward is a diffrax ODE solve, the
@@ -32,24 +32,47 @@ from vardax._src._types import Batch1D
 
 
 class StrongFourDVar(eqx.Module):
-    """Strong-constraint 4DVar.
+    r"""Strong-constraint 4DVar.
 
     Attributes:
         forward: ``pipekit_cycle.ForwardModel`` supplying
             ``step(state, dt) -> state``.
         obs_op: Observation operator.
-        prior_mean: Background :math:`x_b` — initial state of shape
-            ``(N,)`` (state vector at :math:`t=0`).
-        prior_cov_op: :math:`B`.
-        obs_cov_op: :math:`R`.
+        prior_mean: Background $x_b$ — initial state of shape
+            ``(N,)`` (state vector at $t=0$).
+        prior_cov_op: $B$.
+        obs_cov_op: $R$.
         minimiser: ``optimistix.AbstractMinimiser`` for the outer
-            optimisation over :math:`x_0`.
+            optimisation over $x_0$.
         minimiser_adjoint: ``optimistix.AbstractAdjoint`` for
             differentiating through the minimum.
         forward_adjoint: ``diffrax.AbstractAdjoint``-like — currently
             stored as a tag, threaded through if the forward delegates
             to ``diffrax``. Default ``None`` (use forward's own).
         max_steps: Iteration cap on the outer solver.
+
+    Examples:
+        Trivial dynamics ($M_t(x) = x$) and a single timestep reduce
+        strong 4DVar to 3DVar, so with $B = R = I$ the analysis is
+        $x_0^* = y / 2$.
+
+        >>> import jax, jax.numpy as jnp, lineax as lx, vardax
+        >>> class Identity:
+        ...     dt = 1.0
+        ...
+        ...     def step(self, x, dt):
+        ...         return x
+        >>> eye = lx.IdentityLinearOperator(jax.ShapeDtypeStruct((3,), jnp.float32))
+        >>> strong = vardax.StrongFourDVar(
+        ...     forward=Identity(),
+        ...     obs_op=vardax.MaskedIdentity(),
+        ...     prior_mean=jnp.zeros(3),
+        ...     prior_cov_op=eye,
+        ...     obs_cov_op=eye,
+        ... )
+        >>> batch = vardax.Batch1D(input=jnp.ones((1, 1, 3)), mask=jnp.ones((1, 1, 3)))
+        >>> strong(batch).shape
+        (1, 3)
     """
 
     forward: Any
@@ -100,7 +123,7 @@ class StrongFourDVar(eqx.Module):
         return jnp.concatenate([x_0[None, :], trajectory], axis=0)
 
     def __call__(self, batch: Batch1D) -> Float[Array, "B N"]:
-        """Strong-4DVar analysis: minimise over :math:`x_0`."""
+        """Strong-4DVar analysis: minimise over $x_0$."""
 
         T = batch.input.shape[1] - 1  # rollout steps (input has T+1 timesteps)
 

--- a/src/vardax/_src/models/threedvar.py
+++ b/src/vardax/_src/models/threedvar.py
@@ -1,16 +1,16 @@
-"""3D Variational analysis.
+r"""3D Variational analysis.
 
 Minimises
 
-.. math::
+$$
+J(x) = \tfrac{1}{2} \|x - x_b\|^2_{B^{-1}}
+     + \tfrac{1}{2} \|y - H(x)\|^2_{R^{-1}}
+$$
 
-    J(x) = \\tfrac{1}{2} \\|x - x_b\\|^2_{B^{-1}}
-         + \\tfrac{1}{2} \\|y - H(x)\\|^2_{R^{-1}}
-
-over a single timestep. When :math:`H` is linear and :math:`B`, :math:`R`
-Gaussian, ``ThreeDVar`` reduces to ``OptimalInterpolation`` — the
-canonical correctness gate enforced by the linear-Gaussian agreement
-test.
+over a single timestep. When $H$ is linear and $B$, $R$ Gaussian,
+``ThreeDVar`` reduces to [`OptimalInterpolation`][vardax.OptimalInterpolation]
+— the canonical correctness gate enforced by the linear-Gaussian
+agreement test.
 
 The inner minimisation is delegated to an
 ``optimistix.AbstractMinimiser`` (``GaussNewton``, ``BFGS``,
@@ -33,13 +33,13 @@ from vardax._src._types import Batch1D
 
 
 class ThreeDVar(eqx.Module):
-    """3D variational analysis.
+    r"""3D variational analysis.
 
     Attributes:
         obs_op: Observation operator (linear or nonlinear).
-        prior_mean: Background :math:`x_b` of shape ``(T, N)``.
-        prior_cov_op: :math:`B`. ``lineax.AbstractLinearOperator``.
-        obs_cov_op: :math:`R`. ``lineax.AbstractLinearOperator``.
+        prior_mean: Background $x_b$ of shape ``(T, N)``.
+        prior_cov_op: $B$. ``lineax.AbstractLinearOperator``.
+        obs_cov_op: $R$. ``lineax.AbstractLinearOperator``.
         minimiser: ``optimistix.AbstractMinimiser`` for the inner
             iteration. Default ``optimistix.BFGS(rtol=1e-6, atol=1e-6)``.
         minimiser_adjoint: ``optimistix.AbstractAdjoint`` for
@@ -48,6 +48,25 @@ class ThreeDVar(eqx.Module):
             training loop). Default ``ImplicitAdjoint`` — exact at the
             optimum.
         max_steps: Iteration cap on the inner solver.
+
+    Examples:
+        With $B = R = I$, identity $H$ and everything observed, the
+        analysis agrees with the closed-form BLUE, $x^* = y / 2$.
+
+        >>> import jax, jax.numpy as jnp, lineax as lx, vardax
+        >>> eye = lx.IdentityLinearOperator(jax.ShapeDtypeStruct((1, 3), jnp.float32))
+        >>> three = vardax.ThreeDVar(
+        ...     obs_op=vardax.MaskedIdentity(),
+        ...     prior_mean=jnp.zeros((1, 3)),
+        ...     prior_cov_op=eye,
+        ...     obs_cov_op=eye,
+        ... )
+        >>> batch = vardax.Batch1D(input=jnp.ones((1, 1, 3)), mask=jnp.ones((1, 1, 3)))
+        >>> xa = three(batch)
+        >>> xa.shape
+        (1, 1, 3)
+        >>> bool(jnp.allclose(xa, 0.5, atol=1e-3))
+        True
     """
 
     obs_op: Any

--- a/src/vardax/_src/models/weak_fourdvar.py
+++ b/src/vardax/_src/models/weak_fourdvar.py
@@ -1,22 +1,23 @@
-"""Weak-constraint 4DVar.
+r"""Weak-constraint 4DVar.
 
 Multi-time analysis with control variable
-:math:`(x_0, \\eta_1, \\ldots, \\eta_T)` — initial state plus per-step
+$(x_0, \eta_1, \ldots, \eta_T)$ — initial state plus per-step
 model-error increments. Cost:
 
-.. math::
+$$
+J(x_0, \boldsymbol{\eta}) =
+    \tfrac{1}{2} \|x_0 - x_b\|^2_{B^{-1}}
+  + \tfrac{1}{2} \sum_t \|y_t - H_t(x_t)\|^2_{R_t^{-1}}
+  + \tfrac{1}{2} \sum_t \|\eta_t\|^2_{Q_t^{-1}}
+$$
 
-    J(x_0, \\boldsymbol{\\eta}) =
-        \\tfrac{1}{2} \\|x_0 - x_b\\|^2_{B^{-1}}
-      + \\tfrac{1}{2} \\sum_t \\|y_t - H_t(x_t)\\|^2_{R_t^{-1}}
-      + \\tfrac{1}{2} \\sum_t \\|\\eta_t\\|^2_{Q_t^{-1}}
+where $x_t = M_t(x_{t-1}) + \eta_t$.
 
-where :math:`x_t = M_t(x_{t-1}) + \\eta_t`.
-
-The control vector has dimension :math:`(T + 1) \\cdot N` (initial
+The control vector has dimension $(T + 1) \cdot N$ (initial
 state + T model-error increments). For long windows this is
-computationally heavier than ``StrongFourDVar`` — use only when the
-free model :math:`M_t^\\text{free}` is known to have biases.
+computationally heavier than [`StrongFourDVar`][vardax.StrongFourDVar]
+— use only when the free model $M_t^\text{free}$ is known to have
+biases.
 """
 
 from __future__ import annotations
@@ -34,20 +35,47 @@ from vardax._src._types import Batch1D
 
 
 class WeakFourDVar(eqx.Module):
-    """Weak-constraint 4DVar with augmented control vector.
+    r"""Weak-constraint 4DVar with augmented control vector.
 
     Attributes:
-        forward: ``pipekit_cycle.ForwardModel`` (the free model :math:`M_t^\\text{free}`).
+        forward: ``pipekit_cycle.ForwardModel`` (the free model
+            $M_t^\text{free}$).
         obs_op: Observation operator.
-        prior_mean: Background :math:`x_b` — initial state ``(N,)``.
-        prior_cov_op: :math:`B`.
-        obs_cov_op: :math:`R`.
-        model_err_cov_op: :math:`Q` — covariance of the per-step model
-            error :math:`\\eta_t`. Defaults to identity scaled by a
+        prior_mean: Background $x_b$ — initial state ``(N,)``.
+        prior_cov_op: $B$.
+        obs_cov_op: $R$.
+        model_err_cov_op: $Q$ — covariance of the per-step model
+            error $\eta_t$. Defaults to identity scaled by a
             small variance if not supplied (effectively
             strong-constraint with a tiny relaxation).
-        minimiser, minimiser_adjoint, max_steps: as in
-            ``StrongFourDVar``.
+        minimiser: As in [`StrongFourDVar`][vardax.StrongFourDVar].
+        minimiser_adjoint: As in [`StrongFourDVar`][vardax.StrongFourDVar].
+        max_steps: As in [`StrongFourDVar`][vardax.StrongFourDVar].
+
+    Examples:
+        Trivial dynamics and a single timestep: no model-error steps
+        remain ($T = 0$) and the analysis initial state reduces to the
+        3DVar / BLUE answer $x_0^* = y / 2$ for $B = R = I$.
+
+        >>> import jax, jax.numpy as jnp, lineax as lx, vardax
+        >>> class Identity:
+        ...     dt = 1.0
+        ...
+        ...     def step(self, x, dt):
+        ...         return x
+        >>> eye = lx.IdentityLinearOperator(jax.ShapeDtypeStruct((3,), jnp.float32))
+        >>> weak = vardax.WeakFourDVar(
+        ...     forward=Identity(),
+        ...     obs_op=vardax.MaskedIdentity(),
+        ...     prior_mean=jnp.zeros(3),
+        ...     prior_cov_op=eye,
+        ...     obs_cov_op=eye,
+        ...     model_err_cov_op=eye,
+        ... )
+        >>> batch = vardax.Batch1D(input=jnp.ones((1, 1, 3)), mask=jnp.ones((1, 1, 3)))
+        >>> x0_star, eta_star = weak(batch)
+        >>> x0_star.shape, eta_star.shape
+        ((1, 3), (1, 0, 3))
     """
 
     forward: Any
@@ -87,7 +115,10 @@ class WeakFourDVar(eqx.Module):
         x_0: Float[Array, N],  # ty:ignore[unresolved-reference]
         etas: Float[Array, "T N"],
     ) -> Float[Array, "T_plus_1 N"]:
-        """Roll out with per-step model error: :math:`x_t = M_t^\\text{free}(x_{t-1}) + \\eta_t`."""
+        r"""Roll out with per-step model error.
+
+        Each step applies $x_t = M_t^\text{free}(x_{t-1}) + \eta_t$.
+        """
         dt = self.forward.dt
 
         def step_fn(

--- a/src/vardax/_src/obs_operators/__init__.py
+++ b/src/vardax/_src/obs_operators/__init__.py
@@ -1,4 +1,4 @@
-"""Observation operator family.
+r"""Observation operator family.
 
 All operators satisfy ``pipekit_cycle.ObservationOperator`` directly
 (Decision D8): they implement ``__call__(state) -> obs`` and
@@ -12,13 +12,16 @@ they're required for any RTM-derived L2 satellite product.
 
 Public surface:
 
-- :class:`MaskedIdentity`     — :math:`H(x) = m \\odot x`
-- :class:`LinearObs`          — :math:`H(x) = H_\\text{mat} \\cdot x`
-- :class:`AveragingKernel`    — :math:`H(x) = A(h \\cdot x + (1-h) x_a)`
-- :class:`MultiInstrumentFusion` — per-instrument composition at the
-  likelihood level
-- :class:`InstrumentRegistry` — :math:`\\{instrument\\_id : InstrumentSpec\\}`
-- :class:`InstrumentSpec`     — :math:`(obs\\_op, mask, R\\_op, id)` tuple
+- [`MaskedIdentity`][vardax.MaskedIdentity] — $H(x) = m \odot x$
+- [`LinearObs`][vardax.LinearObs] — $H(x) = H_\text{mat} \cdot x$
+- [`AveragingKernel`][vardax.AveragingKernel] —
+  $H(x) = A(h \cdot x + (1-h) x_a)$
+- [`MultiInstrumentFusion`][vardax.MultiInstrumentFusion] —
+  per-instrument composition at the likelihood level
+- [`InstrumentRegistry`][vardax.InstrumentRegistry] —
+  ``{instrument_id: InstrumentSpec}``
+- [`InstrumentSpec`][vardax.InstrumentSpec] —
+  ``(obs_op, mask, R_op, id)`` tuple
 """
 
 from __future__ import annotations

--- a/src/vardax/_src/obs_operators/averaging_kernel.py
+++ b/src/vardax/_src/obs_operators/averaging_kernel.py
@@ -1,16 +1,16 @@
-"""Averaging-kernel observation operator (Decision D9).
+r"""Averaging-kernel observation operator (Decision D9).
 
 For RTM-derived L2 satellite products (TROPOMI CH₄, EMIT CH₄,
 OCO CO₂, MOPITT CO, …), the L2 retrieval is not a direct sample of
-the mixing-ratio profile :math:`x` — it smooths through a kernel
-matrix :math:`A` and falls back to a retrieval prior :math:`x_a`
+the mixing-ratio profile $x$ — it smooths through a kernel
+matrix $A$ and falls back to a retrieval prior $x_a$
 where the signal is weak:
 
-.. math::
+$$
+\hat y = A \, (h \odot x + (1 - h) \odot x_a).
+$$
 
-    \\hat y = A \\, (h \\odot x + (1 - h) \\odot x_a).
-
-Tangent-linear: :math:`H'(x) = A \\cdot \\mathrm{diag}(h)`.
+Tangent-linear: $H'(x) = A \cdot \mathrm{diag}(h)$.
 
 Skipping the averaging kernel is the most common cause of bias in
 operational satellite inversions; vardax exposes it as a first-class
@@ -48,7 +48,7 @@ class AveragingKernel(eqx.Module):
         return self.A.mv(inner)
 
     def linearize(self, x: Float[Array, N]) -> lx.AbstractLinearOperator:  # ty:ignore[unresolved-reference]
-        """Tangent-linear operator at ``x``: :math:`A \\cdot \\mathrm{diag}(h)`."""
+        r"""Tangent-linear operator at ``x``: $A \cdot \mathrm{diag}(h)$."""
         diag_h = lx.DiagonalLinearOperator(self.h)
         return self.A @ diag_h
 

--- a/src/vardax/_src/obs_operators/linear.py
+++ b/src/vardax/_src/obs_operators/linear.py
@@ -16,7 +16,18 @@ import lineax as lx
 
 
 class LinearObs(eqx.Module):
-    """``H(x) = H_mat @ x``."""
+    """``H(x) = H_mat @ x``.
+
+    Examples:
+        >>> import jax.numpy as jnp, lineax as lx
+        >>> import vardax as vdx
+        >>> H = lx.MatrixLinearOperator(jnp.eye(3)[:2])
+        >>> obs = vdx.LinearObs(H_mat=H)
+        >>> obs(jnp.array([1.0, 2.0, 3.0]))
+        Array([1., 2.], dtype=float32)
+        >>> obs.linearize(jnp.zeros(3)) is H
+        True
+    """
 
     H_mat: lx.AbstractLinearOperator
 

--- a/src/vardax/_src/obs_operators/masked.py
+++ b/src/vardax/_src/obs_operators/masked.py
@@ -14,10 +14,20 @@ import lineax as lx
 
 
 class MaskedIdentity(eqx.Module):
-    """:math:`H(x) = m \\odot x` with optional element-wise mask.
+    r"""$H(x) = m \odot x$ with optional element-wise mask.
 
     Stateless: no parameters. The mask can be supplied at call time
     (per-batch) rather than baked in.
+
+    Examples:
+        >>> import jax.numpy as jnp
+        >>> import vardax as vdx
+        >>> op = vdx.MaskedIdentity()
+        >>> x = jnp.array([1.0, 2.0, 3.0])
+        >>> op(x, mask=jnp.array([1.0, 0.0, 1.0]))
+        Array([1., 0., 3.], dtype=float32)
+        >>> type(op.linearize(x)).__name__
+        'JacobianLinearOperator'
     """
 
     def __call__(
@@ -30,5 +40,5 @@ class MaskedIdentity(eqx.Module):
         return x * mask
 
     def linearize(self, x: Float[Array, ...]) -> lx.AbstractLinearOperator:
-        """Tangent-linear operator at ``x``: identity (since :math:`H` is linear)."""
+        """Tangent-linear operator at ``x``: identity (since $H$ is linear)."""
         return lx.JacobianLinearOperator(lambda y, _args=None: y, x)

--- a/src/vardax/_src/obs_operators/multi_instrument.py
+++ b/src/vardax/_src/obs_operators/multi_instrument.py
@@ -1,7 +1,7 @@
-"""Multi-instrument observation-operator fusion (Decision D9).
+r"""Multi-instrument observation-operator fusion (Decision D9).
 
 Operational satellite work combines multiple instruments. Each has
-its own :math:`H_i`, mask :math:`m_i`, error covariance :math:`R_i`,
+its own $H_i$, mask $m_i$, error covariance $R_i$,
 and possibly its own averaging kernel. ``MultiInstrumentFusion``
 composes per-instrument operators at the **likelihood level** — no
 pre-regridding to a common grid, no assumption of shared coordinate
@@ -9,18 +9,21 @@ systems.
 
 The fused observation cost:
 
-.. math::
-
-    J_\\text{obs}(x) = \\sum_{i \\in \\mathcal{I}} \\alpha_i \\cdot
-                       \\tfrac{1}{2} \\|m_i \\odot (y_i - H_i(x))\\|^2_{R_i^{-1}}.
+$$
+J_\text{obs}(x) = \sum_{i \in \mathcal{I}} \alpha_i \cdot
+                  \tfrac{1}{2} \|m_i \odot (y_i - H_i(x))\|^2_{R_i^{-1}}.
+$$
 
 This module ships:
 
-- :class:`InstrumentSpec`     — :math:`(obs\\_op, mask, R\\_op, id)` tuple
-- :class:`InstrumentRegistry` — :math:`\\{instrument\\_id : InstrumentSpec\\}`
-- :class:`MultiInstrumentFusion` — composes the registry; returns
-  per-instrument ``dict[str, Array]`` of predicted observations. For
-  strict-protocol contexts (``pipekit_cycle.ObservationOperator``), the
+- [`InstrumentSpec`][vardax.InstrumentSpec] — ``(obs_op, mask, R_op, id)``
+  tuple
+- [`InstrumentRegistry`][vardax.InstrumentRegistry] —
+  ``{instrument_id: InstrumentSpec}``
+- [`MultiInstrumentFusion`][vardax.MultiInstrumentFusion] — composes the
+  registry; returns per-instrument ``dict[str, Array]`` of predicted
+  observations. For strict-protocol contexts
+  (``pipekit_cycle.ObservationOperator``), the
   ``.to_observation_operator()`` adapter flattens to a single output
   with a block-diagonal linear operator.
 """
@@ -40,7 +43,7 @@ class InstrumentSpec(eqx.Module):
 
     Attributes:
         obs_op: ``ObservationOperator``-conforming operator (typically
-            :class:`AveragingKernel`).
+            [`AveragingKernel`][vardax.AveragingKernel]).
         mask: Quality mask of shape compatible with the instrument's
             observation space. ``1`` for valid pixels, ``0`` for
             flagged/dropped.
@@ -69,11 +72,11 @@ class InstrumentRegistry(eqx.Module):
 
 
 class MultiInstrumentFusion(eqx.Module):
-    """Compose per-instrument operators at the likelihood level.
+    r"""Compose per-instrument operators at the likelihood level.
 
     ``__call__`` returns ``dict[instrument_id, predicted_obs]`` — one
     array per instrument. The cost function consumes the dict and
-    sums per-instrument terms with their respective :math:`R_i^{-1}`.
+    sums per-instrument terms with their respective $R_i^{-1}$.
     There is no shared coordinate system; each instrument keeps its
     native footprint and resolution.
 
@@ -82,9 +85,10 @@ class MultiInstrumentFusion(eqx.Module):
     call ``.to_observation_operator()`` for a flattened wrapper.
 
     Attributes:
-        registry: Per-instrument :class:`InstrumentRegistry`.
+        registry: Per-instrument
+            [`InstrumentRegistry`][vardax.InstrumentRegistry].
         weights: Optional ``{instrument_id: alpha}`` mapping. ``None``
-            ⇒ uniform :math:`\\alpha_i = 1`.
+            ⇒ uniform $\alpha_i = 1$.
     """
 
     registry: InstrumentRegistry

--- a/src/vardax/_src/posterior/__init__.py
+++ b/src/vardax/_src/posterior/__init__.py
@@ -1,18 +1,21 @@
-"""Posterior adapters (Decision D10).
+r"""Posterior adapters (Decision D10).
 
-Every vardax analysis emits a ``Posterior`` container — not just a
-point estimate. Three adapter families compute the posterior covariance
-via different approximations:
+Every vardax analysis emits a [`Posterior`][vardax.Posterior]
+container — not just a point estimate. Three adapter families compute
+the posterior covariance via different approximations:
 
-- :class:`LaplaceCovariance`   — :math:`P^* = (B^{-1} + H^\\top R^{-1} H)^{-1}`
-  at MAP. Cheap, Gaussian-likelihood-only.
-- :class:`GaussNewtonHessian`  — Krylov / Lanczos inversion of the
-  Gauss-Newton Hessian. Exact at MAP, structured.
-- :class:`EnsembleCovariance`  — sample covariance from an ensemble of
-  analyses (delegates to ``filterax`` when supplied).
+- [`LaplaceCovariance`][vardax.LaplaceCovariance] —
+  $P^* = (B^{-1} + H^\top R^{-1} H)^{-1}$ at MAP. Cheap,
+  Gaussian-likelihood-only.
+- [`GaussNewtonHessian`][vardax.GaussNewtonHessian] — Krylov / Lanczos
+  inversion of the Gauss-Newton Hessian. Exact at MAP, structured.
+- [`EnsembleCovariance`][vardax.EnsembleCovariance] — sample covariance
+  from an ensemble of analyses (delegates to ``filterax`` when
+  supplied).
 
-Plus :class:`GaussianMarkLikelihood` — serialises a ``Posterior``
-to a JSON-friendly dict for downstream population models (Tier V).
+Plus [`GaussianMarkLikelihood`][vardax.GaussianMarkLikelihood] —
+serialises a [`Posterior`][vardax.Posterior] to a JSON-friendly dict
+for downstream population models (Tier V).
 """
 
 from __future__ import annotations

--- a/src/vardax/_src/posterior/adapter.py
+++ b/src/vardax/_src/posterior/adapter.py
@@ -29,6 +29,16 @@ class GaussianMarkLikelihood(eqx.Module):
     Use ``.to_dict()`` to get a JSON-friendly representation that
     downstream consumers (GeoCatalog, hierarchical Bayesian models,
     DuckDB ingest) can store as-is.
+
+    Examples:
+        >>> import jax.numpy as jnp
+        >>> import vardax as vdx
+        >>> post = vdx.Posterior(mean=jnp.zeros(3))
+        >>> mark = vdx.GaussianMarkLikelihood(
+        ...     posterior=post, event_metadata={"event_id": "e1"}
+        ... )
+        >>> sorted(mark.to_dict())
+        ['cov_diag', 'event_metadata', 'mean', 'provenance', 'samples']
     """
 
     posterior: Posterior

--- a/src/vardax/_src/posterior/container.py
+++ b/src/vardax/_src/posterior/container.py
@@ -28,8 +28,20 @@ class Posterior(eqx.Module):
             for analytical adapters.
         provenance: Free-form dict carrying audit info — at minimum
             ``{forward_model_id, n_iter, J_star, converged,
-            vardax_version}``. Consumed by ``GaussianMarkLikelihood``
+            vardax_version}``. Consumed by
+            [`GaussianMarkLikelihood`][vardax.GaussianMarkLikelihood]
             when serialising for downstream population models.
+
+    Examples:
+        >>> import jax.numpy as jnp
+        >>> import vardax as vdx
+        >>> post = vdx.Posterior(mean=jnp.zeros(4))
+        >>> post.mean.shape
+        (4,)
+        >>> post.cov is None
+        True
+        >>> post.provenance
+        {}
     """
 
     mean: Float[Array, ...]

--- a/src/vardax/_src/posterior/ensemble.py
+++ b/src/vardax/_src/posterior/ensemble.py
@@ -1,11 +1,11 @@
-"""Ensemble-covariance posterior adapter.
+r"""Ensemble-covariance posterior adapter.
 
 Builds the posterior covariance from an ensemble of analyses
 (per perturbed initial condition or observation realisation):
 
-.. math::
-
-    P^* \\approx \\frac{1}{M-1} \\sum_m (x^{(m)} - \\bar x)(x^{(m)} - \\bar x)^\\top.
+$$
+P^* \approx \frac{1}{M-1} \sum_m (x^{(m)} - \bar x)(x^{(m)} - \bar x)^\top.
+$$
 
 When ``filterax`` is installed and used for the propagation, this
 adapter just packages the sample covariance into a ``Posterior``.
@@ -29,11 +29,11 @@ from .container import Posterior
 
 
 class EnsembleCovariance(eqx.Module):
-    """Sample-covariance posterior from an ensemble of analyses.
+    r"""Sample-covariance posterior from an ensemble of analyses.
 
     Attributes:
         n_members: Expected ensemble size (used for diagnostics).
-        inflation: Multiplicative inflation factor :math:`\\lambda` applied
+        inflation: Multiplicative inflation factor $\lambda$ applied
             to the sample covariance. Default 1.0 (no inflation).
     """
 
@@ -56,9 +56,10 @@ class EnsembleCovariance(eqx.Module):
                 compatibility).
 
         Returns:
-            ``Posterior`` with mean = ensemble mean, ``cov`` = sample
-            covariance as a dense ``MatrixLinearOperator`` (only
-            assembled if you ask for it; safe for moderate M).
+            [`Posterior`][vardax.Posterior] with mean = ensemble mean,
+            ``cov`` = sample covariance as a dense
+            ``MatrixLinearOperator`` (only assembled if you ask for
+            it; safe for moderate M).
         """
         m = analyses.shape[0]
         if m != self.n_members:

--- a/src/vardax/_src/posterior/gauss_newton.py
+++ b/src/vardax/_src/posterior/gauss_newton.py
@@ -1,12 +1,12 @@
-"""Gauss-Newton Hessian posterior (Decision D10).
+r"""Gauss-Newton Hessian posterior (Decision D10).
 
 For ``IncrementalFourDVar`` the Gauss-Newton Hessian is assembled
 during the last outer iteration as part of the algorithm. Reuse it
 for posterior covariance:
 
-.. math::
-
-    P^* = \\big(B^{-1} + \\sum_t (H'_t M'_t)^\\top R_t^{-1} (H'_t M'_t)\\big)^{-1}.
+$$
+P^* = \big(B^{-1} + \sum_t (H'_t M'_t)^\top R_t^{-1} (H'_t M'_t)\big)^{-1}.
+$$
 
 For methods that don't assemble the GN Hessian as a side effect
 (``StrongFourDVar``, ``WeakFourDVar``), this adapter computes it
@@ -27,17 +27,18 @@ from .laplace import _CG_SOLVER, _inverse_op
 
 
 class GaussNewtonHessian(eqx.Module):
-    """Gauss-Newton Hessian inversion at MAP.
+    r"""Gauss-Newton Hessian inversion at MAP.
 
-    Functionally similar to ``LaplaceCovariance`` — both compute
-    :math:`(B^{-1} + H^\\top R^{-1} H)^{-1}` (or its 4D extension)
+    Functionally similar to
+    [`LaplaceCovariance`][vardax.LaplaceCovariance] — both compute
+    $(B^{-1} + H^\top R^{-1} H)^{-1}$ (or its 4D extension)
     — but the GN-Hessian adapter is the recommended path for
     ``IncrementalFourDVar`` where the Hessian is already
     materialised by the inner CG solver.
 
     Attributes:
-        prior_cov_op: :math:`B`.
-        obs_cov_op: :math:`R`.
+        prior_cov_op: $B$.
+        obs_cov_op: $R$.
         n_krylov: Maximum Krylov iterations for mat-vec evaluations.
     """
 

--- a/src/vardax/_src/posterior/laplace.py
+++ b/src/vardax/_src/posterior/laplace.py
@@ -1,15 +1,14 @@
-"""Laplace approximation at MAP.
+r"""Laplace approximation at MAP.
 
-For Gaussian-likelihood / Gaussian-prior problems at the MAP
-:math:`x^*`:
+For Gaussian-likelihood / Gaussian-prior problems at the MAP $x^*$:
 
-.. math::
-
-    P^* \\approx \\big((H')^\\top R^{-1} H' + B^{-1}\\big)^{-1}.
+$$
+P^* \approx \big((H')^\top R^{-1} H' + B^{-1}\big)^{-1}.
+$$
 
 The result is returned as an ``AbstractLinearOperator`` so mat-vec
 (samples, marginals) compose lazily via ``lineax.CG`` without
-materialising :math:`P^*`.
+materialising $P^*$.
 
 Use when:
 
@@ -37,15 +36,29 @@ from .container import Posterior
 
 
 class LaplaceCovariance(eqx.Module):
-    """Laplace approximation at MAP.
+    r"""Laplace approximation at MAP.
 
     Attributes:
-        prior_cov_op: Background-error covariance :math:`B`.
-        obs_cov_op: Observation-error covariance :math:`R`.
+        prior_cov_op: Background-error covariance $B$.
+        obs_cov_op: Observation-error covariance $R$.
 
-    Both required so the adapter can build :math:`P^*` lazily. They
+    Both required so the adapter can build $P^*$ lazily. They
     should match the operators used by the analysis method that
     produced ``analysis``.
+
+    Examples:
+        >>> import jax, jax.numpy as jnp, lineax as lx
+        >>> import vardax as vdx
+        >>> from types import SimpleNamespace
+        >>> eye = lx.IdentityLinearOperator(jax.ShapeDtypeStruct((4,), jnp.float32))
+        >>> laplace = vdx.LaplaceCovariance(prior_cov_op=eye, obs_cov_op=eye)
+        >>> model = SimpleNamespace(obs_op=vdx.LinearObs(H_mat=eye))
+        >>> post = laplace(jnp.zeros(4), model, batch=None)
+        >>> post.mean.shape
+        (4,)
+        >>> # B = R = H = I, so P* = (I + I)^{-1} = I / 2
+        >>> bool(jnp.allclose(post.cov.mv(jnp.ones(4)), 0.5, atol=1e-2))
+        True
     """
 
     prior_cov_op: lx.AbstractLinearOperator
@@ -68,8 +81,9 @@ class LaplaceCovariance(eqx.Module):
                 to recover the mask, instrument bookkeeping, etc.).
 
         Returns:
-            ``Posterior`` with ``mean = analysis`` and ``cov`` as a
-            lazy ``AbstractLinearOperator`` representing :math:`P^*`.
+            [`Posterior`][vardax.Posterior] with ``mean = analysis``
+            and ``cov`` as a lazy ``AbstractLinearOperator``
+            representing $P^*$.
         """
         # Pull the obs operator off either an .as_analysis_step()
         # wrapper or the raw model. Both expose ``obs_op``.
@@ -106,7 +120,7 @@ _CG_SOLVER = lx.CG(atol=1e-6, rtol=1e-6, max_steps=200)
 
 
 def _inverse_op(op: lx.AbstractLinearOperator) -> lx.AbstractLinearOperator:
-    """Lazy PSD inverse — delegates to :func:`gaussx.inv`.
+    """Lazy PSD inverse — delegates to ``gaussx.inv``.
 
     Structured operators (diagonal, Kronecker, block-diagonal,
     low-rank) invert in closed form; everything else solves via

--- a/src/vardax/_src/priors.py
+++ b/src/vardax/_src/priors.py
@@ -54,6 +54,15 @@ class BilinAEPrior1D(eqx.Module):
         state_dim: Spatial size of the input (``N``).
         latent_dim: Dimensionality of the latent code.
         n_time: Number of time steps (``T``).
+
+    Examples:
+        >>> import jax, jax.numpy as jnp
+        >>> from vardax import BilinAEPrior1D
+        >>> prior = BilinAEPrior1D(
+        ...     state_dim=4, latent_dim=2, n_time=3, key=jax.random.PRNGKey(0)
+        ... )
+        >>> prior(jnp.ones((2, 3, 4))).shape
+        (2, 3, 4)
     """
 
     state_dim: int = eqx.field(static=True)
@@ -232,11 +241,19 @@ class BilinAEPrior2DMultivar(eqx.Module):
 
 
 class IdentityPrior(eqx.Module):
-    """Trivial identity prior: :math:`\\varphi(x) = x`.
+    r"""Trivial identity prior: $\varphi(x) = x$.
 
     Zero parameters. Useful as a pure obs-driven baseline (the prior
     cost vanishes everywhere) and as a sanity-check building block in
     the linear-Gaussian agreement tests.
+
+    Examples:
+        >>> import jax.numpy as jnp
+        >>> from vardax import IdentityPrior
+        >>> prior = IdentityPrior()
+        >>> x = jnp.arange(6.0).reshape(1, 2, 3)
+        >>> bool(jnp.all(prior(x) == x))
+        True
     """
 
     def __call__(self, x: Float[Array, ...]) -> Float[Array, ...]:

--- a/src/vardax/_src/protocols.py
+++ b/src/vardax/_src/protocols.py
@@ -1,15 +1,19 @@
-"""Runtime-checkable protocols used across vardax.
+r"""Runtime-checkable protocols used across vardax.
 
 vardax re-exports the three core ``pipekit_cycle`` protocols
 (`ForwardModel`, `ObservationOperator`, `AnalysisStep`) and adds five
 vardax-specific protocols that ``pipekit-cycle`` doesn't name:
 
-- `Prior`            — :math:`\\varphi: x \\mapsto x_\\text{prior}`
-- `GradModulator`    — :math:`\\Phi: (\\nabla J, h) \\mapsto (\\Delta x, h')`
-- `CostFunction`     — :math:`J: (x, \\text{batch}) \\mapsto \\text{scalar}`
-- `PosteriorAdapter` — analysis output → ``Posterior``
-- `Minimiser`        — wraps `optimistix.AbstractMinimiser` over vardax's
-  cost-function interface
+- [`Prior`][vardax.Prior] — $\varphi: x \mapsto x_\text{prior}$
+- [`GradModulator`][vardax.GradModulator] —
+  $\Phi: (\nabla J, h) \mapsto (\Delta x, h')$
+- [`CostFunction`][vardax.CostFunction] —
+  $J: (x, \text{batch}) \mapsto \text{scalar}$
+- [`PosteriorAdapter`][vardax.PosteriorAdapter] — analysis output →
+  [`Posterior`][vardax.Posterior]
+- [`Minimiser`][vardax.Minimiser] — wraps
+  ``optimistix.AbstractMinimiser`` over vardax's cost-function
+  interface
 
 All protocols are ``@runtime_checkable`` so ``isinstance(obj, Protocol)``
 works for structural conformance checking — used by
@@ -37,9 +41,9 @@ from pipekit_cycle import (
 
 @runtime_checkable
 class Prior(Protocol):
-    """Prior model: maps state to its regularised reconstruction.
+    r"""Prior model: maps state to its regularised reconstruction.
 
-    For an autoencoder prior :math:`\\varphi_\\theta`, the variational
+    For an autoencoder prior $\varphi_\theta$, the variational
     cost includes ``||x - φ(x)||^2``. For a dynamical prior wrapping a
     `ForwardModel`, ``φ(x)`` is the forward integration. For the
     identity prior, ``φ(x) = x``.

--- a/src/vardax/_src/solver.py
+++ b/src/vardax/_src/solver.py
@@ -70,7 +70,7 @@ def init_solver_state_1d(
         hidden_dim: Hidden dimension of the ConvLSTM gradient modulator.
 
     Returns:
-        Zero-initialised :class:`SolverState1D`.
+        Zero-initialised [`SolverState1D`][vardax.SolverState1D].
     """
     b, _, n = batch.input.shape
     x0 = batch.input * batch.mask
@@ -89,7 +89,7 @@ def init_solver_state_2d(
         hidden_dim: Hidden dimension of the ConvLSTM gradient modulator.
 
     Returns:
-        Zero-initialised :class:`SolverState2D`.
+        Zero-initialised [`SolverState2D`][vardax.SolverState2D].
     """
     b, _, h, w = batch.input.shape
     x0 = batch.input * batch.mask
@@ -110,7 +110,7 @@ def solver_step_1d(
     alpha: float = 1.0,
     prior_weight: float = 1.0,
 ) -> SolverState1D:
-    """Perform a single 1-D solver iteration.
+    r"""Perform a single 1-D solver iteration.
 
     Computes the gradient of the variational cost, then passes it through
     the learned gradient modulator to obtain a state update.
@@ -121,10 +121,10 @@ def solver_step_1d(
         prior_fn: Callable ``x -> x_prior`` (prior autoencoder forward pass).
         grad_mod_fn: Callable ``(grad, x, lstm) -> (update, new_lstm)``.
         alpha: Step-size scaling factor.
-        prior_weight: Weighting factor :math:`\\lambda` for the prior cost term.
+        prior_weight: Weighting factor $\lambda$ for the prior cost term.
 
     Returns:
-        Updated :class:`SolverState1D`.
+        Updated [`SolverState1D`][vardax.SolverState1D].
     """
     x = solver_state.x
 
@@ -150,7 +150,7 @@ def solver_step_2d(
     alpha: float = 1.0,
     prior_weight: float = 1.0,
 ) -> SolverState2D:
-    """Perform a single 2-D solver iteration.
+    r"""Perform a single 2-D solver iteration.
 
     Args:
         solver_state: Current solver state.
@@ -158,10 +158,10 @@ def solver_step_2d(
         prior_fn: Callable ``x -> x_prior``.
         grad_mod_fn: Callable ``(grad, x, lstm) -> (update, new_lstm)``.
         alpha: Step-size scaling factor.
-        prior_weight: Weighting factor :math:`\\lambda` for the prior cost term.
+        prior_weight: Weighting factor $\lambda$ for the prior cost term.
 
     Returns:
-        Updated :class:`SolverState2D`.
+        Updated [`SolverState2D`][vardax.SolverState2D].
     """
     x = solver_state.x
 
@@ -248,15 +248,15 @@ def fp_solver_step_1d(
     batch: Batch1D,
     prior_fn: Any,
 ) -> Float[Array, "B T N"]:
-    """Perform a single 1-D fixed-point projection step.
+    r"""Perform a single 1-D fixed-point projection step.
 
     Applies the prior projection then re-inserts observations at observed
     locations:
 
-    .. math::
-
-        x \\leftarrow \\varphi(x), \\quad
-        x \\leftarrow m \\odot y + (1 - m) \\odot x
+    $$
+    x \leftarrow \varphi(x), \quad
+    x \leftarrow m \odot y + (1 - m) \odot x
+    $$
 
     Args:
         x: Current state estimate of shape ``(B, T, N)``.
@@ -276,10 +276,11 @@ def solve_4dvarnet_1d_fixedpoint(
     prior_fn: Any,
     n_fp_steps: int,
 ) -> Float[Array, "B T N"]:
-    """Run ``n_fp_steps`` fixed-point projection steps using :func:`jax.lax.scan`.
+    """Run ``n_fp_steps`` fixed-point projection steps using ``jax.lax.scan``.
 
     Initialises the state from the masked observations, then iterates the
-    fixed-point update :func:`fp_solver_step_1d` for ``n_fp_steps`` steps.
+    fixed-point update [`fp_solver_step_1d`][vardax.fp_solver_step_1d] for
+    ``n_fp_steps`` steps.
 
     Args:
         batch: Observed data batch.
@@ -313,7 +314,7 @@ def one_step_solve_4dvarnet_1d(
     alpha: float = 1.0,
     prior_weight: float = 1.0,
 ) -> Float[Array, "B T N"]:
-    """Solve 4DVarNet-1D using one-step differentiation (Bolte et al., 2023).
+    r"""Solve 4DVarNet-1D using one-step differentiation (Bolte et al., 2023).
 
     Runs ``n_steps - 1`` solver iterations with ``jax.lax.stop_gradient``
     applied to the iterate, then performs a single final step through which
@@ -332,7 +333,7 @@ def one_step_solve_4dvarnet_1d(
             then 1 differentiable step).
         hidden_dim: Hidden dimension of the ConvLSTM gradient modulator.
         alpha: Step-size scaling factor.
-        prior_weight: Weighting factor :math:`\\lambda` for the prior cost term.
+        prior_weight: Weighting factor $\lambda$ for the prior cost term.
 
     Returns:
         Final state estimate of shape ``(B, T, N)``.
@@ -366,7 +367,7 @@ def one_step_solve_4dvarnet_2d(
     alpha: float = 1.0,
     prior_weight: float = 1.0,
 ) -> Float[Array, "B T H W"]:
-    """Solve 4DVarNet-2D using one-step differentiation (Bolte et al., 2023).
+    r"""Solve 4DVarNet-2D using one-step differentiation (Bolte et al., 2023).
 
     Runs ``n_steps - 1`` solver iterations with ``jax.lax.stop_gradient``
     applied to the iterate, then performs a single final step through which
@@ -385,7 +386,7 @@ def one_step_solve_4dvarnet_2d(
             then 1 differentiable step).
         hidden_dim: Hidden dimension of the ConvLSTM gradient modulator.
         alpha: Step-size scaling factor.
-        prior_weight: Weighting factor :math:`\\lambda` for the prior cost term.
+        prior_weight: Weighting factor $\lambda$ for the prior cost term.
 
     Returns:
         Final state estimate of shape ``(B, T, H, W)``.

--- a/src/vardax/_src/training.py
+++ b/src/vardax/_src/training.py
@@ -118,14 +118,14 @@ def amortized_nll_loss_fn(
     model: Any,
     batch: Batch1D | Batch2D,
 ) -> Float[Array, ""]:
-    """Negative log-likelihood for amortized inference (Epic 8).
+    r"""Negative log-likelihood for amortized inference (Epic 8).
 
     For ``AmortizedPosterior`` with flow / regression heads the maximum-
     likelihood objective on simulated pairs is
 
-    .. math::
-
-        \\mathcal{L}_\\text{MLE}(\\phi) = -\\mathbb{E}_{(x, y)} \\log q_\\phi(x \\mid y).
+    $$
+    \mathcal{L}_\text{MLE}(\phi) = -\mathbb{E}_{(x, y)} \log q_\phi(x \mid y).
+    $$
 
     Args:
         model: ``AmortizedPosterior`` (any head with a ``.log_prob``

--- a/src/vardax/_src/utils/__init__.py
+++ b/src/vardax/_src/utils/__init__.py
@@ -1,12 +1,12 @@
 """Utility subpackage for vardax.
 
-Submodules
-----------
-dynamical_systems : L63 ODE model and simulation helper.
-patches           : xarray patch extraction from trajectories.
-masks             : Observation mask generators.
-noise             : Gaussian noise injection.
-standardize       : Mean/std standardization and inverse transform.
-preprocessing     : xarray → JAX conversion and train/test split.
-viz               : Visualization helpers (soft matplotlib dependency).
+Submodules:
+
+- ``dynamical_systems`` — L63 ODE model and simulation helper.
+- ``patches`` — xarray patch extraction from trajectories.
+- ``masks`` — Observation mask generators.
+- ``noise`` — Gaussian noise injection.
+- ``standardize`` — Mean/std standardization and inverse transform.
+- ``preprocessing`` — xarray → JAX conversion and train/test split.
+- ``viz`` — Visualization helpers (soft matplotlib dependency).
 """

--- a/src/vardax/_src/utils/dynamical_systems.py
+++ b/src/vardax/_src/utils/dynamical_systems.py
@@ -54,33 +54,22 @@ def simulate_lorenz63(
 ) -> tuple[Float[Array, T], Float[Array, "T 3"]]:  # type: ignore[unresolved-reference]  # ty:ignore[unresolved-reference]
     """Simulate the Lorenz-63 system and return state trajectory.
 
-    Parameters
-    ----------
-    key:
-        JAX PRNG key used to perturb the initial condition when ``x0`` is
-        ``None``.
-    sigma:
-        Prandtl number.
-    rho:
-        Rayleigh number.
-    beta:
-        Geometric factor.
-    dt:
-        Integration time step.
-    n_steps:
-        Total number of integration steps *after* burn-in.
-    n_burn_in:
-        Number of initial steps to discard (burn-in).
-    x0:
-        Optional explicit initial condition of shape ``(3,)``.  When
-        ``None``, the classic fixed-point perturbation is used.
+    Args:
+        key: JAX PRNG key used to perturb the initial condition when
+            ``x0`` is ``None``.
+        sigma: Prandtl number.
+        rho: Rayleigh number.
+        beta: Geometric factor.
+        dt: Integration time step.
+        n_steps: Total number of integration steps *after* burn-in.
+        n_burn_in: Number of initial steps to discard (burn-in).
+        x0: Optional explicit initial condition of shape ``(3,)``.  When
+            ``None``, the classic fixed-point perturbation is used.
 
-    Returns
-    -------
-    time_coords : Float[Array, "T"]
-        Time coordinates for the returned trajectory (starting at 0).
-    states : Float[Array, "T 3"]
-        State trajectory of the Lorenz-63 system.
+    Returns:
+        ``(time_coords, states)`` — time coordinates of shape ``(T,)``
+        (starting at 0) and the Lorenz-63 state trajectory of shape
+        ``(T, 3)``.
     """
     model = Lorenz63(sigma=sigma, rho=rho, beta=beta)
 
@@ -154,27 +143,18 @@ def simulate_lorenz96(
 ) -> tuple[Float[Array, T], Float[Array, "T N"]]:  # type: ignore[unresolved-reference]  # ty:ignore[unresolved-reference]
     """Simulate the Lorenz-96 system and return state trajectory.
 
-    Parameters
-    ----------
-    key:
-        JAX PRNG key used to perturb the initial condition.
-    N:
-        Number of variables (spatial dimension).
-    F:
-        Forcing constant.
-    dt:
-        Integration time step.
-    n_steps:
-        Total number of integration steps *after* burn-in.
-    n_burn_in:
-        Number of initial steps to discard (burn-in).
+    Args:
+        key: JAX PRNG key used to perturb the initial condition.
+        N: Number of variables (spatial dimension).
+        F: Forcing constant.
+        dt: Integration time step.
+        n_steps: Total number of integration steps *after* burn-in.
+        n_burn_in: Number of initial steps to discard (burn-in).
 
-    Returns
-    -------
-    time_coords : Float[Array, "T"]
-        Time coordinates for the returned trajectory (starting at 0).
-    states : Float[Array, "T N"]
-        State trajectory of shape ``(n_steps + 1, N)``.
+    Returns:
+        ``(time_coords, states)`` — time coordinates of shape ``(T,)``
+        (starting at 0) and the state trajectory of shape
+        ``(n_steps + 1, N)``.
     """
     model = Lorenz96(F=F)
 

--- a/src/vardax/_src/utils/masks.py
+++ b/src/vardax/_src/utils/masks.py
@@ -17,20 +17,13 @@ def random_mask(
 
     A value of ``1`` means *observed*; ``0`` means *missing*.
 
-    Parameters
-    ----------
-    ds:
-        Dataset containing ``variable``.
-    variable:
-        Name of the variable to mask.
-    missing_rate:
-        Fraction of values to mark as missing (in ``[0, 1)``).
-    seed:
-        Random seed for reproducibility.
+    Args:
+        ds: Dataset containing ``variable``.
+        variable: Name of the variable to mask.
+        missing_rate: Fraction of values to mark as missing (in ``[0, 1)``).
+        seed: Random seed for reproducibility.
 
-    Returns
-    -------
-    xr.Dataset
+    Returns:
         Dataset with an additional ``"mask"`` coordinate that shares the
         same dimensions as ``variable``.
     """
@@ -52,19 +45,13 @@ def regular_mask(
     Every ``obs_interval``-th timestep along the ``time`` dimension is
     marked as observed (``1``); all others are ``0``.
 
-    Parameters
-    ----------
-    ds:
-        Dataset containing ``variable``.
-    variable:
-        Name of the variable to mask.
-    obs_interval:
-        Spacing between observed timesteps (every ``obs_interval``-th step
-        is observed).
+    Args:
+        ds: Dataset containing ``variable``.
+        variable: Name of the variable to mask.
+        obs_interval: Spacing between observed timesteps (every
+            ``obs_interval``-th step is observed).
 
-    Returns
-    -------
-    xr.Dataset
+    Returns:
         Dataset with an additional ``"mask"`` coordinate.
     """
     da = ds[variable]
@@ -95,21 +82,14 @@ def feature_mask(
 ) -> xr.Dataset:
     """Add a feature-dimension mask to the dataset.
 
-    Parameters
-    ----------
-    ds:
-        Dataset containing ``variable``.
-    variable:
-        Name of the variable to mask.
-    coord:
-        Name of the coordinate that enumerates feature dimensions.
-    observed_dims:
-        Feature names that should be marked as *observed* (``1``); all
-        others are ``0``.
+    Args:
+        ds: Dataset containing ``variable``.
+        variable: Name of the variable to mask.
+        coord: Name of the coordinate that enumerates feature dimensions.
+        observed_dims: Feature names that should be marked as *observed*
+            (``1``); all others are ``0``.
 
-    Returns
-    -------
-    xr.Dataset
+    Returns:
         Dataset with an additional ``"mask_features"`` coordinate sharing
         the same dimensions as ``variable``.
     """

--- a/src/vardax/_src/utils/noise.py
+++ b/src/vardax/_src/utils/noise.py
@@ -19,23 +19,16 @@ def add_gaussian_noise(
     Computes ``noisy = variable + σ * ε`` where ``ε ~ N(0, 1)`` and adds
     ``noisy`` as a new variable named ``name`` to the dataset.
 
-    Parameters
-    ----------
-    ds:
-        Dataset containing ``variable``.
-    variable:
-        Name of the source variable.
-    sigma:
-        Standard deviation of the additive Gaussian noise.
-    seed:
-        Random seed for reproducibility (via ``numpy.random.default_rng``).
-    name:
-        Name of the new noisy variable added to the dataset (default
-        ``"obs"``).
+    Args:
+        ds: Dataset containing ``variable``.
+        variable: Name of the source variable.
+        sigma: Standard deviation of the additive Gaussian noise.
+        seed: Random seed for reproducibility (via
+            ``numpy.random.default_rng``).
+        name: Name of the new noisy variable added to the dataset
+            (default ``"obs"``).
 
-    Returns
-    -------
-    xr.Dataset
+    Returns:
         Dataset with the new ``name`` variable added.
     """
     rng = np.random.default_rng(seed)

--- a/src/vardax/_src/utils/patches.py
+++ b/src/vardax/_src/utils/patches.py
@@ -15,19 +15,13 @@ def trajectory_to_xr_dataset(
 ) -> xr.Dataset:
     """Convert a state trajectory to an xarray Dataset.
 
-    Parameters
-    ----------
-    states:
-        State trajectory of shape ``(T, F)``.
-    time_coords:
-        Time coordinates of shape ``(T,)``.
-    feature_names:
-        Names for the feature dimensions.  Defaults to
-        ``["x0", "x1", ..., "x{F-1}"]``.
+    Args:
+        states: State trajectory of shape ``(T, F)``.
+        time_coords: Time coordinates of shape ``(T,)``.
+        feature_names: Names for the feature dimensions.  Defaults to
+            ``["x0", "x1", ..., "x{F-1}"]``.
 
-    Returns
-    -------
-    xr.Dataset
+    Returns:
         Dataset with a ``"state"`` DataArray of dims ``(time, feature)``.
     """
     states_np = np.asarray(states)
@@ -57,20 +51,14 @@ def extract_patches(
 ) -> xr.Dataset:
     """Extract random temporal patches from a trajectory dataset.
 
-    Parameters
-    ----------
-    ds:
-        Dataset with a ``"state"`` DataArray of dims ``(time, feature)``.
-    n_patches:
-        Number of patches to extract.
-    n_timesteps:
-        Length (in timesteps) of each patch.
-    seed:
-        Random seed for reproducibility.
+    Args:
+        ds: Dataset with a ``"state"`` DataArray of dims
+            ``(time, feature)``.
+        n_patches: Number of patches to extract.
+        n_timesteps: Length (in timesteps) of each patch.
+        seed: Random seed for reproducibility.
 
-    Returns
-    -------
-    xr.Dataset
+    Returns:
         Dataset with a ``"state"`` DataArray of dims
         ``(patch, time, feature)``.
     """

--- a/src/vardax/_src/utils/preprocessing.py
+++ b/src/vardax/_src/utils/preprocessing.py
@@ -20,23 +20,14 @@ def train_test_split(
 ) -> tuple[xr.Dataset, xr.Dataset]:
     """Randomly split a patched dataset along the ``patch`` dimension.
 
-    Parameters
-    ----------
-    ds:
-        Dataset with a ``patch`` dimension.
-    n_train:
-        Number of patches for the training set.
-    n_test:
-        Number of patches for the test set.
-    seed:
-        Random seed for reproducibility.
+    Args:
+        ds: Dataset with a ``patch`` dimension.
+        n_train: Number of patches for the training set.
+        n_test: Number of patches for the test set.
+        seed: Random seed for reproducibility.
 
-    Returns
-    -------
-    ds_train : xr.Dataset
-        Training subset.
-    ds_test : xr.Dataset
-        Test subset.
+    Returns:
+        ``(ds_train, ds_test)`` — the training and test subsets.
     """
     rng = np.random.default_rng(seed)
     n_patches = ds.sizes["patch"]
@@ -64,30 +55,23 @@ def xr_to_batch1d(
     obs_var: str = "obs",
     mask_var: str = "mask",
 ) -> Batch1D:
-    """Convert an xarray Dataset to a :class:`~vardax.Batch1D`.
+    """Convert an xarray Dataset to a [`Batch1D`][vardax.Batch1D].
 
     The dataset is expected to have dims ``(patch, time, feature)``; the
     feature dimension is treated as the spatial ``N`` axis of
-    :class:`~vardax.Batch1D`.
+    [`Batch1D`][vardax.Batch1D].
 
-    Parameters
-    ----------
-    ds:
-        Dataset with variables ``state_var``, ``obs_var``, and
-        ``mask_var``, each of shape ``(patch, time, feature)``.
-    state_var:
-        Name of the ground-truth state variable (→ ``target``).
-    obs_var:
-        Name of the observed / noisy variable (→ ``input``).
-    mask_var:
-        Name of the binary mask variable (→ ``mask``).
+    Args:
+        ds: Dataset with variables ``state_var``, ``obs_var``, and
+            ``mask_var``, each of shape ``(patch, time, feature)``.
+        state_var: Name of the ground-truth state variable (→ ``target``).
+        obs_var: Name of the observed / noisy variable (→ ``input``).
+        mask_var: Name of the binary mask variable (→ ``mask``).
 
-    Returns
-    -------
-    Batch1D
-        Named tuple with ``input``, ``mask``, and ``target`` as JAX
-        arrays of shape ``(B, T, N)`` where ``B = patch``, ``T = time``,
-        and ``N = feature``.
+    Returns:
+        [`Batch1D`][vardax.Batch1D] with ``input``, ``mask``, and
+        ``target`` as JAX arrays of shape ``(B, T, N)`` where
+        ``B = patch``, ``T = time``, and ``N = feature``.
     """
     target = jnp.array(ds[state_var].values)
     inp = jnp.array(ds[obs_var].values)
@@ -108,24 +92,17 @@ def interpolate_initial_condition(
     For each patch, linearly interpolates the observed values across the
     time axis to produce a dense initial-condition estimate.
 
-    Parameters
-    ----------
-    ds:
-        Dataset with ``obs_var`` and ``mask_var``, dims
-        ``(patch, time, feature)``.
-    obs_var:
-        Name of the (noisy) observation variable.
-    mask_var:
-        Name of the binary observation mask.
-    method:
-        Interpolation method passed to
-        :func:`numpy.interp` along the time axis (``"linear"`` only).
-    fillna:
-        Fill value for leading/trailing gaps that cannot be interpolated.
+    Args:
+        ds: Dataset with ``obs_var`` and ``mask_var``, dims
+            ``(patch, time, feature)``.
+        obs_var: Name of the (noisy) observation variable.
+        mask_var: Name of the binary observation mask.
+        method: Interpolation method passed to ``numpy.interp`` along
+            the time axis (``"linear"`` only).
+        fillna: Fill value for leading/trailing gaps that cannot be
+            interpolated.
 
-    Returns
-    -------
-    xr.Dataset
+    Returns:
         Dataset with an additional ``"x_init"`` variable of shape
         ``(patch, time, feature)``.
     """
@@ -168,40 +145,32 @@ def obs_interpolation_init(
 ) -> xr.Dataset:
     """Interpolate observations along time and add as ``"state_init"``.
 
-    Uses :meth:`xr.DataArray.interpolate_na` to fill NaN gaps along the
+    Uses ``xr.DataArray.interpolate_na`` to fill NaN gaps along the
     time dimension, then fills any remaining NaNs (e.g. leading/trailing
     edges) with ``fillna``.  The result is stored as a new ``"state_init"``
     variable — a warm-start initial condition for the 4DVar solver.
 
-    Parameters
-    ----------
-    ds:
-        Dataset containing at least ``obs_variable``, which should have NaN
-        at unobserved locations.
-    variable:
-        Name of the ground-truth state variable (unused for interpolation,
-        kept for API symmetry).
-    obs_variable:
-        Name of the observation variable (NaN where unobserved).
-    method:
-        Interpolation method passed to
-        :meth:`xr.DataArray.interpolate_na` (default ``"linear"``).
-    fillna:
-        Fill value for any remaining NaN after interpolation (default
-        ``0.0``).
+    Args:
+        ds: Dataset containing at least ``obs_variable``, which should
+            have NaN at unobserved locations.
+        variable: Name of the ground-truth state variable (unused for
+            interpolation, kept for API symmetry).
+        obs_variable: Name of the observation variable (NaN where
+            unobserved).
+        method: Interpolation method passed to
+            ``xr.DataArray.interpolate_na`` (default ``"linear"``).
+        fillna: Fill value for any remaining NaN after interpolation
+            (default ``0.0``).
 
-    Returns
-    -------
-    xr.Dataset
+    Returns:
         Dataset with an additional ``"state_init"`` variable of the same
         shape as ``obs_variable``.
 
-    Notes
-    -----
-    The time dimension is assumed to be the *second* dimension of
-    ``obs_variable`` (i.e. ``dims[1]`` for shape
-    ``(patch, time, feature)``), which matches the standard vardax
-    dataset layout produced by :func:`extract_patches`.
+    Note:
+        The time dimension is assumed to be the *second* dimension of
+        ``obs_variable`` (i.e. ``dims[1]`` for shape
+        ``(patch, time, feature)``), which matches the standard vardax
+        dataset layout produced by ``extract_patches``.
     """
     obs_da = ds[obs_variable]
     if "time" in obs_da.dims:

--- a/src/vardax/_src/utils/standardize.py
+++ b/src/vardax/_src/utils/standardize.py
@@ -15,22 +15,17 @@ def compute_scaler_params(
 ) -> tuple[float, float]:
     """Compute mean and standard deviation from (optionally masked) data.
 
-    Parameters
-    ----------
-    ds:
-        Dataset containing ``variable`` and optionally ``mask_variable``.
-    variable:
-        Name of the data variable.
-    mask_variable:
-        Name of the binary mask variable (``1`` = observed).  When
-        ``None`` or absent from the dataset, all values are used.
+    Args:
+        ds: Dataset containing ``variable`` and optionally
+            ``mask_variable``.
+        variable: Name of the data variable.
+        mask_variable: Name of the binary mask variable (``1`` =
+            observed).  When ``None`` or absent from the dataset, all
+            values are used.
 
-    Returns
-    -------
-    mean : float
-        Mean of the observed values.
-    std : float
-        Standard deviation of the observed values.
+    Returns:
+        ``(mean, std)`` — mean and standard deviation of the observed
+        values.
     """
     values = np.asarray(ds[variable])
 
@@ -69,20 +64,13 @@ def apply_standardization(
     Applies ``(x − mean) / std`` to each listed variable in-place (returns
     a new dataset).
 
-    Parameters
-    ----------
-    ds:
-        Source dataset.
-    variables:
-        List of variable names to standardize.
-    mean:
-        Mean value to subtract.
-    std:
-        Standard deviation to divide by.
+    Args:
+        ds: Source dataset.
+        variables: List of variable names to standardize.
+        mean: Mean value to subtract.
+        std: Standard deviation to divide by.
 
-    Returns
-    -------
-    xr.Dataset
+    Returns:
         Dataset with the listed variables replaced by their standardized
         versions.
     """
@@ -104,18 +92,12 @@ def inverse_standardization(
 ) -> Float[Array, ...]:
     """Reverse a standardization transform on a JAX array.
 
-    Parameters
-    ----------
-    data:
-        Standardized data.
-    mean:
-        Mean that was subtracted during standardization.
-    std:
-        Standard deviation that was divided during standardization.
+    Args:
+        data: Standardized data.
+        mean: Mean that was subtracted during standardization.
+        std: Standard deviation that was divided during standardization.
 
-    Returns
-    -------
-    Float[Array, "..."]
+    Returns:
         Array in the original scale.
     """
     return data * std + mean

--- a/src/vardax/_src/utils/validation.py
+++ b/src/vardax/_src/utils/validation.py
@@ -1,12 +1,12 @@
-"""Six-step cycle validation gates (Decision D12 / Epic 8).
+r"""Six-step cycle validation gates (Decision D12 / Epic 8).
 
 Amortized inference is dangerous when miscalibrated — a tight
-:math:`q_\\phi` centred wrong gives confident wrong answers. Decision
+$q_\phi$ centred wrong gives confident wrong answers. Decision
 D12 (chapter 14 of the math reference) requires three gates before any
 amortized head is promoted to operational use:
 
 1. **Posterior agreement** — the fast model's MAP lies within
-   :math:`\\sigma_\\text{post}` of an oracle MAP from a slower method.
+   $\sigma_\text{post}$ of an oracle MAP from a slower method.
 2. **Adjoint calibration** — the fast model's sensitivity to
    observations matches the physics-based sensitivity, measured by
    random-vector probing of the Jacobian.
@@ -39,18 +39,18 @@ def assert_posterior_agreement(
     *,
     tolerance_sigma: float = 1.0,
 ) -> None:
-    """Check that ``p_fast.mean`` lies within ``tolerance_sigma`` standard
+    r"""Check that ``p_fast.mean`` lies within ``tolerance_sigma`` standard
     deviations of ``p_oracle.mean``.
 
     Marginal-only test: each component of the mean must satisfy
 
-    .. math::
+    $$
+    \frac{|x^*_\text{fast} - x^*_\text{oracle}|}{\sigma_\text{post, oracle}}
+    \le \text{tolerance\_sigma}.
+    $$
 
-        \\frac{|x^*_\\text{fast} - x^*_\\text{oracle}|}{\\sigma_\\text{post, oracle}}
-        \\le \\text{tolerance\\_sigma}.
-
-    The oracle marginal :math:`\\sigma_i` is extracted from
-    ``p_oracle.cov`` by probing ``e_i^T \\Sigma e_i`` via one matvec per
+    The oracle marginal $\sigma_i$ is extracted from
+    ``p_oracle.cov`` by probing $e_i^T \Sigma e_i$ via one matvec per
     component. Cheap for moderate state size; for very large state
     sizes use Hutchinson estimation upstream and supply the diagonal
     directly via ``Posterior.cov`` materialised as a diagonal operator.
@@ -58,8 +58,8 @@ def assert_posterior_agreement(
     Args:
         p_fast: Posterior produced by the amortized / fast model.
         p_oracle: Posterior produced by the oracle (e.g. ``StrongFourDVar``
-            + ``LaplaceCovariance``).
-        tolerance_sigma: Allowed deviation in units of :math:`\\sigma`.
+            + [`LaplaceCovariance`][vardax.LaplaceCovariance]).
+        tolerance_sigma: Allowed deviation in units of $\sigma$.
 
     Raises:
         AssertionError: If any component exceeds the tolerance.
@@ -92,16 +92,16 @@ def assert_adjoint_calibrated(
     threshold: float = 0.05,
     n_probes: int = 10,
 ) -> None:
-    """Random-vector probe of the Jacobian agreement at ``y``.
+    r"""Random-vector probe of the Jacobian agreement at ``y``.
 
     Tests
 
-    .. math::
+    $$
+    \frac{\|J_\text{fast} v - J_\text{oracle} v\|}
+         {\|J_\text{oracle} v\|} < \text{threshold}
+    $$
 
-        \\frac{\\|J_\\text{fast} v - J_\\text{oracle} v\\|}
-             {\\|J_\\text{oracle} v\\|} < \\text{threshold}
-
-    for ``n_probes`` random unit vectors :math:`v`. Avoids
+    for ``n_probes`` random unit vectors $v$. Avoids
     materialising either Jacobian — uses ``jax.jvp`` to apply each as
     needed. Cheaper than dense Jacobian comparison and is the
     operational test used by the six-step cycle.
@@ -144,17 +144,17 @@ def simulation_based_calibration(
     n_runs: int = 200,
     n_samples: int = 200,
 ) -> Float[Array, " n_runs"]:
-    """Per Talts et al. 2018: rank histogram of true draws within
+    r"""Per Talts et al. 2018: rank histogram of true draws within
     posterior samples.
 
     Procedure for each of ``n_runs`` independent draws:
 
-    1. Sample :math:`x^{(j)} \\sim p(x)` from the prior.
-    2. Simulate :math:`y^{(j)} = \\mathrm{simulate\\_obs}(x^{(j)})`.
+    1. Sample $x^{(j)} \sim p(x)$ from the prior.
+    2. Simulate $y^{(j)} = \mathrm{simulate\_obs}(x^{(j)})$.
     3. Draw ``n_samples`` posterior samples from
-       :math:`q_\\phi(\\cdot \\mid y^{(j)})`.
+       $q_\phi(\cdot \mid y^{(j)})$.
     4. Compute the rank of (a flattened scalar reduction of)
-       :math:`x^{(j)}` in the sample set.
+       $x^{(j)}$ in the sample set.
 
     A well-calibrated posterior produces uniformly distributed ranks
     over ``[0, n_samples]``. Bumps near the edges → over-confident;
@@ -191,9 +191,9 @@ def simulation_based_calibration(
 
 
 def _marginal_std(cov_op: Any, ref: Float[Array, ...]) -> Float[Array, ...]:
-    """Extract :math:`\\sqrt{\\mathrm{diag}(\\Sigma)}` from the operator.
+    r"""Extract $\sqrt{\mathrm{diag}(\Sigma)}$ from the operator.
 
-    Delegates to :func:`gaussx.diag`, which uses closed forms for
+    Delegates to ``gaussx.diag``, which uses closed forms for
     structured operators (diagonal, Kronecker, block-diagonal) and
     falls back to materialisation only for generic operators — fine
     for the moderate-N regime where this gate is meaningful.

--- a/src/vardax/_src/utils/viz.py
+++ b/src/vardax/_src/utils/viz.py
@@ -25,19 +25,13 @@ def plot_3d_attractor(
 ) -> tuple[Figure, Axes]:
     """Plot a 3-D attractor trajectory.
 
-    Parameters
-    ----------
-    states:
-        State array of shape ``(T, D)`` with ``D >= 3``.
-    dim_indices:
-        Indices of the three dimensions to plot.
-    ax:
-        Optional existing 3-D ``Axes`` to draw on.
+    Args:
+        states: State array of shape ``(T, D)`` with ``D >= 3``.
+        dim_indices: Indices of the three dimensions to plot.
+        ax: Optional existing 3-D ``Axes`` to draw on.
 
-    Returns
-    -------
-    fig, ax : Figure, Axes
-        Matplotlib figure and 3-D axes.
+    Returns:
+        ``(fig, ax)`` — Matplotlib figure and 3-D axes.
     """
     import matplotlib.pyplot as plt
 
@@ -64,18 +58,13 @@ def plot_state_grid(
 ) -> tuple[Figure, Axes]:
     """Hovmöller-style image of states over time.
 
-    Parameters
-    ----------
-    states:
-        State array of shape ``(T, N)``.
-    time:
-        Time coordinate array of shape ``(T,)``.
-    ax:
-        Optional existing ``Axes`` to draw on.
+    Args:
+        states: State array of shape ``(T, N)``.
+        time: Time coordinate array of shape ``(T,)``.
+        ax: Optional existing ``Axes`` to draw on.
 
-    Returns
-    -------
-    fig, ax : Figure, Axes
+    Returns:
+        ``(fig, ax)`` — Matplotlib figure and axes.
     """
     import matplotlib.pyplot as plt
 
@@ -105,21 +94,15 @@ def plot_trajectories(
 ) -> tuple[Figure, Axes]:
     """Overlay time-series of all state variables.
 
-    Parameters
-    ----------
-    states:
-        State array of shape ``(T, N)``.
-    time:
-        Time coordinate array of shape ``(T,)``.
-    ax:
-        Optional existing ``Axes`` to draw on.
-    orientation:
-        ``"horizontal"`` plots time on the x-axis; ``"vertical"`` rotates
-        so that time is on the y-axis.
+    Args:
+        states: State array of shape ``(T, N)``.
+        time: Time coordinate array of shape ``(T,)``.
+        ax: Optional existing ``Axes`` to draw on.
+        orientation: ``"horizontal"`` plots time on the x-axis;
+            ``"vertical"`` rotates so that time is on the y-axis.
 
-    Returns
-    -------
-    fig, ax : Figure, Axes
+    Returns:
+        ``(fig, ax)`` — Matplotlib figure and axes.
     """
     import matplotlib.pyplot as plt
 
@@ -153,20 +136,14 @@ def plot_reconstruction_comparison(
 ) -> tuple[Figure, np.ndarray]:
     """Side-by-side comparison of target, masked input, and reconstruction.
 
-    Parameters
-    ----------
-    target:
-        Ground-truth states of shape ``(B, T, N)``.
-    masked_input:
-        Masked / noisy observations of shape ``(B, T, N)``.
-    reconstruction:
-        Model reconstruction of shape ``(B, T, N)``.
-    sample_idx:
-        Which batch element to visualize.
+    Args:
+        target: Ground-truth states of shape ``(B, T, N)``.
+        masked_input: Masked / noisy observations of shape ``(B, T, N)``.
+        reconstruction: Model reconstruction of shape ``(B, T, N)``.
+        sample_idx: Which batch element to visualize.
 
-    Returns
-    -------
-    fig, axes : Figure, array of Axes
+    Returns:
+        ``(fig, axes)`` — Matplotlib figure and array of axes.
     """
     import matplotlib.pyplot as plt
 
@@ -193,18 +170,13 @@ def plot_l96_grid(
 ) -> tuple[Figure, Axes]:
     """Hovmöller-style image of Lorenz-96 states over time.
 
-    Parameters
-    ----------
-    states:
-        State array of shape ``(T, N)``.
-    time_coords:
-        Time coordinate array of shape ``(T,)``.
-    ax:
-        Optional existing ``Axes`` to draw on.
+    Args:
+        states: State array of shape ``(T, N)``.
+        time_coords: Time coordinate array of shape ``(T,)``.
+        ax: Optional existing ``Axes`` to draw on.
 
-    Returns
-    -------
-    fig, ax : Figure, Axes
+    Returns:
+        ``(fig, ax)`` — Matplotlib figure and axes.
     """
     import matplotlib.pyplot as plt
 
@@ -239,20 +211,14 @@ def plot_l96_trajectories(
 ) -> tuple[Figure, Axes]:
     """Line plot of selected Lorenz-96 variables over time.
 
-    Parameters
-    ----------
-    states:
-        State array of shape ``(T, N)``.
-    time_coords:
-        Time coordinate array of shape ``(T,)``.
-    n_vars:
-        Number of evenly-spaced variables to plot.
-    ax:
-        Optional existing ``Axes`` to draw on.
+    Args:
+        states: State array of shape ``(T, N)``.
+        time_coords: Time coordinate array of shape ``(T,)``.
+        n_vars: Number of evenly-spaced variables to plot.
+        ax: Optional existing ``Axes`` to draw on.
 
-    Returns
-    -------
-    fig, ax : Figure, Axes
+    Returns:
+        ``(fig, ax)`` — Matplotlib figure and axes.
     """
     import matplotlib.pyplot as plt
 

--- a/tests/test_docstrings.py
+++ b/tests/test_docstrings.py
@@ -1,0 +1,114 @@
+"""Docstring quality gates for the rendered API docs.
+
+mkdocstrings renders docstrings through griffe's Google-style parser,
+and three classes of mistake silently degrade the built docs:
+
+* Doctest code under a header griffe does not recognise as an examples
+  section (e.g. singular ``Example:``) is parsed as a generic
+  admonition, and the ``>>>`` lines collapse into a run-together
+  paragraph instead of a highlighted code block.
+* Sphinx/RST math roles (``:math:``, ``.. math::``) are not rendered
+  by MkDocs — equations must use arithmatex ``$...$`` / ``$$...$$``.
+* Unbalanced ``$$`` math fences leave raw TeX in the rendered page.
+
+These tests parse every docstring in the package exactly the way the
+docs build does and fail on any of the three, so the problems cannot
+reach the published site again.
+"""
+
+from __future__ import annotations
+
+import griffe
+from griffe import Docstring, DocstringSectionKind, Parser
+import pytest
+
+
+def _iter_docstrings(obj, seen):
+    """Yield (path, Docstring) for every object defined in vardax."""
+    if obj.path in seen:
+        return
+    seen.add(obj.path)
+    if obj.docstring is not None:
+        yield obj.path, obj.docstring
+    members = getattr(obj, "members", {})
+    for member in members.values():
+        # Skip aliases (re-exports): pipekit-owned docstrings are
+        # tested upstream, and vardax-owned ones are reached at their
+        # definition site.
+        if member.is_alias:
+            continue
+        yield from _iter_docstrings(member, seen)
+
+
+@pytest.fixture(scope="module")
+def all_docstrings() -> list[tuple[str, Docstring]]:
+    pkg = griffe.load("vardax", search_paths=["src"])
+    docstrings = list(_iter_docstrings(pkg, set()))
+    assert len(docstrings) > 50  # the walk found the real package
+    return docstrings
+
+
+def test_doctests_parse_as_examples_sections(all_docstrings):
+    """Every ``>>>`` snippet must land in a real examples section.
+
+    A doctest inside a text or admonition section means the section
+    header is one griffe does not recognise (the ``Example:`` vs
+    ``Examples:`` trap) and the code will render as prose.
+    """
+    offenders = []
+    for path, docstring in all_docstrings:
+        for section in docstring.parse(Parser.google):
+            if section.kind is DocstringSectionKind.examples:
+                continue
+            if section.kind is DocstringSectionKind.admonition:
+                text = section.value.contents
+            elif section.kind is DocstringSectionKind.text:
+                text = section.value
+            else:
+                continue
+            if ">>>" in str(text):
+                offenders.append(f"{path} ({section.kind.value})")
+    assert not offenders, (
+        "Doctest code outside an examples section — use the plural "
+        f"'Examples:' header so mkdocstrings renders it as code: {offenders}"
+    )
+
+
+def test_examples_sections_contain_code(all_docstrings):
+    """Parsed examples sections must carry at least one code part."""
+    offenders = []
+    for path, docstring in all_docstrings:
+        for section in docstring.parse(Parser.google):
+            if section.kind is not DocstringSectionKind.examples:
+                continue
+            kinds = [kind for kind, _ in section.value]
+            if DocstringSectionKind.examples not in kinds:
+                offenders.append(path)
+    assert not offenders, f"Examples sections without doctest code: {offenders}"
+
+
+def test_no_sphinx_math_roles(all_docstrings):
+    """Equations must use arithmatex ``$``/``$$`` syntax, not RST roles.
+
+    MkDocs does not render ``:math:`` or ``.. math::`` — they appear
+    as literal text in the built pages.
+    """
+    offenders = [
+        path
+        for path, docstring in all_docstrings
+        if ":math:" in docstring.value or ".. math::" in docstring.value
+    ]
+    assert not offenders, (
+        f"Sphinx math roles do not render under MkDocs — use $...$ "
+        f"inline or $$...$$ display blocks instead: {offenders}"
+    )
+
+
+def test_math_fences_are_balanced(all_docstrings):
+    """``$$`` math fences must come in pairs, or raw TeX leaks into the docs."""
+    offenders = [
+        path
+        for path, docstring in all_docstrings
+        if docstring.value.count("$$") % 2 != 0
+    ]
+    assert not offenders, f"Unbalanced $$ math fences: {offenders}"


### PR DESCRIPTION
## Summary

vardax had **no generated API reference** — the nav's "API" entries were hand-written design docs — and the docstrings could not have rendered correctly anyway: mkdocstrings was configured for **numpy** style while 10 of 17 documented modules used Google sections (those rendered as plain text), and **113 Sphinx math roles** (`:math:`, `.. math::`) display as literal text under MkDocs. This PR builds the API reference to the gaussx standard and makes every docstring MkDocs-compatible, with regression tests so the known rendering traps can't return.

### API reference (`docs/api/`, gaussx style)
Ten themed pages — prose context + grouped mkdocstrings members blocks — covering all 85 public exports exactly once (no duplicate anchors): overview, models, amortized inference, observation operators, posterior covariance, costs/priors/solvers, training & adjoints, cycle integration, protocols & types, utilities. The pipekit protocol re-exports render via `preload_modules: [pipekit_cycle]`; the two optimistix re-exports griffe can't resolve are linked as bullets with prose instead.

### mkdocs.yml
Switched to `docstring_style: google` with the gaussx mkdocstrings option set (table-style sections, signature crossrefs, symbol-type headings/TOC, private-member filter, source-relative `paths: [src]`) and added the API Reference nav section.

### Docstring normalization
- numpy-style sections converted to Google across `utils/` (and everywhere else they appeared) so one parser fits the whole package.
- All `:math:` / `.. math::` converted to arithmatex `$…$` / `$$…$$` (raw-string prefixes added where LaTeX backslashes appear); RST `code-block` directives and `:class:`/`:func:` roles converted to fenced blocks and mkdocs `[name][path]` cross-references. Unicode math stays in `#` comments only.
- 15 **verified** doctest `Examples:` sections (plural — the singular `Example:` header renders as run-together prose) on the key public APIs: the five classical models, `LinearObs`, `MaskedIdentity`, `VarDACycle`, `LaplaceCovariance`, `Posterior`, `GaussianMarkLikelihood`, costs and priors. Every output was executed and pasted verbatim. Bonus catch: a fake module-level doctest in `da_cycle.py` (undefined variable) is now a non-doctest code fence.

### Regression gates (`tests/test_docstrings.py`)
Parse every docstring exactly as the docs build does (griffe, Google parser) and fail on: doctests outside a real examples section, examples sections without code, any Sphinx math role, or unbalanced `$$` fences. `griffe` added to the test dependency group so the gates run in CI.

## Test plan
- [x] `uv run pytest` — 224 passed (220 baseline + 4 gates)
- [x] doctests for all 15 new examples pass
- [x] `ruff check .` / `ruff format --check .` / `ty check src/vardax` — clean
- [x] `mkdocs build` — clean (only the Material-for-MkDocs 2.0 banner)
- [x] Built HTML inspected: examples render as highlighted code blocks, zero leftover `:math:` text, MathJax `arithmatex` spans present (34 on the models page alone), all model anchors resolve

https://claude.ai/code/session_018xVoXd1zzxK6cZGbSUgakd

---
_Generated by [Claude Code](https://claude.ai/code/session_018xVoXd1zzxK6cZGbSUgakd)_