### PR TITLE
feat: k-step adjoints and the pipekit adjoint-spec interpreter

### DIFF
--- a/docs/12_adjoint_methods.md
+++ b/docs/12_adjoint_methods.md
@@ -243,6 +243,44 @@ in `BacksolveAdjoint` (switch to an implicit integrator), or
 under-converged optimisation in `ImplicitAdjoint` (tighten the
 tolerance).
 
+## The shared strategy vocabulary
+
+The same concepts recur at every layer, so the stack shares one
+declarative vocabulary: the frozen-dataclass specs in
+`pipekit_cycle.adjoints` (named after their diffrax counterparts).
+Each layer interprets a spec into its native mechanism —
+`pipekit_jax.to_diffrax_adjoint` at the dynamics layer,
+[`to_optimistix_adjoint`][vardax.adjoints.to_optimistix_adjoint] at the
+inner-solve layer (this chapter), and filterax's scan strategies at the
+cycle layer:
+
+| Spec | dynamics (diffrax) | inner solve (optimistix / vardax) | cycle (filterax scan) |
+|---|---|---|---|
+| `DirectAdjoint` | `diffrax.DirectAdjoint` | unrolled (the default) | plain scan |
+| `RecursiveCheckpointAdjoint` | `diffrax.RecursiveCheckpointAdjoint` | `optx.RecursiveCheckpointAdjoint` | checkpointed scan |
+| `TruncatedAdjoint(k)` | — | [`KStepAdjoint(k)`][vardax.adjoints.KStepAdjoint]; `k=1` ≡ `OneStepAdjoint` | truncated scan |
+| `ImplicitAdjoint` | steady-state only | `optx.ImplicitAdjoint` | — |
+| `BacksolveAdjoint` | `diffrax.BacksolveAdjoint` ⚠ unstable for chaotic/stiff dynamics | — | — |
+
+```python
+from pipekit_cycle.adjoints import TruncatedAdjoint
+from vardax.adjoints import to_optimistix_adjoint
+
+model = FourDVarNet1D(
+    ...,
+    solver_adjoint=to_optimistix_adjoint(TruncatedAdjoint(k=3)),
+)
+```
+
+`KStepAdjoint` generalises the one-step strategy: at a converged fixed
+point any $k$ is exact (the warmup contributes nothing); for the
+truncated, unconverged solvers of 4DVarNet, larger $k$ trades memory
+for a less biased gradient. The dynamics layer composes independently:
+a `pipekit_jax.DiffraxForwardModel` slots into
+[`StrongFourDVar`][vardax.StrongFourDVar] as a plain
+`pipekit_cycle.ForwardModel`, bringing diffrax's solvers and adjoints
+to the forecast step with no vardax code changes.
+
 ## Adjoint selection heuristics
 
 | Scenario | Pick |

--- a/docs/api/training.md
+++ b/docs/api/training.md
@@ -34,14 +34,16 @@ see the optimistix documentation for their full signatures:
   implicit-function-theorem differentiation at a fixed point; pair with
   `solve_4dvarnet_1d_fixedpoint`.
 
-`OneStepAdjoint` is vardax's own truncated adjoint (Bolte, Pauwels &
+`KStepAdjoint(k)` is vardax's own truncated adjoint — warmup under
+`stop_gradient`, then `k` differentiable steps; `OneStepAdjoint` is the
+`k=1` alias (Bolte, Pauwels &
 Vaiter, NeurIPS 2023):
 
 ::: vardax
     options:
       show_root_heading: false
       show_root_toc_entry: false
-      members: [OneStepAdjoint]
+      members: [KStepAdjoint, OneStepAdjoint, to_optimistix_adjoint]
 
 ## Gradient modulators
 

--- a/src/vardax/__init__.py
+++ b/src/vardax/__init__.py
@@ -23,8 +23,10 @@ from vardax._src._types import (
 )
 from vardax._src.adjoints import (
     ImplicitAdjoint,
+    KStepAdjoint,
     OneStepAdjoint,
     RecursiveCheckpointAdjoint,
+    to_optimistix_adjoint,
 )
 from vardax._src.amortized import (
     AmortizedConfig,
@@ -179,7 +181,9 @@ __all__ = [
     "ConvLSTMGradMod2D",
     # Adjoints (Decision D15 — replaces v0.1 grad_mode enum)
     "ImplicitAdjoint",
+    "KStepAdjoint",
     "OneStepAdjoint",
+    "to_optimistix_adjoint",
     "RecursiveCheckpointAdjoint",
     # Solver
     "SolverState1D",

--- a/src/vardax/_src/adjoints/__init__.py
+++ b/src/vardax/_src/adjoints/__init__.py
@@ -27,9 +27,15 @@ The choice replaces the v0.3 ``grad_mode: Literal["unrolled",
 
 This module ships:
 
-- [`OneStepAdjoint`][vardax.OneStepAdjoint] — Bolte, Pauwels & Vaiter
-  (NeurIPS 2023); the only vardax-owned adjoint. Subclasses
-  ``optimistix.AbstractAdjoint`` and targets upstream contribution.
+- [`KStepAdjoint`][vardax.adjoints.KStepAdjoint] — warmup under
+  ``stop_gradient``, then ``k`` differentiable steps (Bolte, Pauwels &
+  Vaiter, NeurIPS 2023, generalised). The vardax-owned adjoint;
+  targets upstream contribution.
+- [`OneStepAdjoint`][vardax.OneStepAdjoint] — the ``k=1`` alias.
+- [`to_optimistix_adjoint`][vardax.adjoints.to_optimistix_adjoint] —
+  interpreter for the shared ``pipekit_cycle.adjoints`` spec
+  vocabulary (``TruncatedAdjoint(k)`` maps here; the dynamics-layer
+  counterpart is ``pipekit_jax.to_diffrax_adjoint``).
 - Re-exports ``optimistix.RecursiveCheckpointAdjoint`` and
   ``optimistix.ImplicitAdjoint`` for one-stop import.
 """
@@ -42,11 +48,15 @@ from optimistix import (
     RecursiveCheckpointAdjoint,
 )
 
+from .k_step import KStepAdjoint
+from .mapping import to_optimistix_adjoint
 from .one_step import OneStepAdjoint
 
 __all__ = [
     "AbstractAdjoint",
     "ImplicitAdjoint",
+    "KStepAdjoint",
     "OneStepAdjoint",
     "RecursiveCheckpointAdjoint",
+    "to_optimistix_adjoint",
 ]

--- a/src/vardax/_src/adjoints/k_step.py
+++ b/src/vardax/_src/adjoints/k_step.py
@@ -1,0 +1,85 @@
+r"""K-step differentiation of iterative algorithms.
+
+Generalises the one-step strategy of Bolte, Pauwels & Vaiter (2023):
+run the first ``n_steps - k`` iterations of the inner solver under
+``jax.lax.stop_gradient``, then ``k`` differentiable steps. Memory for
+the backward pass is $O(k)$ regardless of the total iteration count,
+and at a converged fixed point the estimator is exact for any ``k``
+(the warmup iterations contribute nothing). For unconverged, truncated
+solvers — the 4DVarNet regime — larger ``k`` trades memory for a less
+biased gradient.
+
+``KStepAdjoint(k=1)`` is exactly
+[`OneStepAdjoint`][vardax.adjoints.OneStepAdjoint], which remains as
+the familiar alias. In the shared pipekit vocabulary this strategy is
+``pipekit_cycle.adjoints.TruncatedAdjoint(k)`` applied at the
+inner-solve layer — see
+[`to_optimistix_adjoint`][vardax.adjoints.to_optimistix_adjoint].
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from jaxtyping import Array, PyTree
+import optimistix as optx
+
+
+class KStepAdjoint(optx.AbstractAdjoint):
+    """K-step differentiation: warmup under ``stop_gradient``, then ``k`` live steps.
+
+    Use as the ``solver_adjoint`` argument to
+    [`FourDVarNet1D`][vardax.FourDVarNet1D] /
+    [`FourDVarNet2D`][vardax.FourDVarNet2D]:
+
+    ```python
+    from vardax.adjoints import KStepAdjoint
+
+    model = FourDVarNet1D(
+        state_dim=N, n_time=T, ...,
+        solver_adjoint=KStepAdjoint(k=3),
+        key=key,
+    )
+    ```
+
+    Attributes:
+        k: Number of trailing solver iterations that propagate
+            gradients. Must be at least 1; values larger than
+            ``n_solver_steps`` are clipped to a fully differentiable
+            solve.
+
+    References:
+        Bolte, J., Pauwels, E. & Vaiter, S. (2023). One-step
+        differentiation of iterative algorithms. NeurIPS 36.
+        [arXiv:2305.13768](https://arxiv.org/abs/2305.13768).
+    """
+
+    k: int = 1
+
+    def __check_init__(self) -> None:
+        if self.k < 1:
+            raise ValueError(f"KStepAdjoint needs k >= 1; got k={self.k}.")
+
+    def apply(
+        self,
+        primal_fn: Callable,
+        rewrite_fn: Callable,
+        inputs: PyTree,
+        tags: frozenset[object],
+    ) -> PyTree[Array]:
+        """Not used by vardax's custom learned solver — dispatch happens
+        in ``vardax._src.solver`` via ``isinstance`` on the adjoint type.
+
+        Implementing this method for upstream ``optimistix.minimise``
+        compatibility is tracked under the planned upstream
+        contribution (Decision D6).
+        """
+        raise NotImplementedError(
+            "KStepAdjoint is currently a marker / strategy selector for the "
+            "FourDVarNet inner solver. Generic apply() support for "
+            "optimistix.minimise is planned as part of the upstream "
+            "contribution. Use it via FourDVarNet*(solver_adjoint=KStepAdjoint(k=...))."
+        )
+
+    def __repr__(self) -> str:  # pragma: no cover - cosmetic
+        return f"KStepAdjoint(k={self.k})"

--- a/src/vardax/_src/adjoints/mapping.py
+++ b/src/vardax/_src/adjoints/mapping.py
@@ -1,0 +1,81 @@
+"""Map pipekit adjoint specs onto optimistix adjoints.
+
+The shared vocabulary lives in ``pipekit_cycle.adjoints`` (frozen
+dataclasses named after their diffrax counterparts); vardax's inner
+solvers consume ``optimistix.AbstractAdjoint`` instances. This module
+is the inner-solve-layer interpreter — the counterpart of
+``pipekit_jax.to_diffrax_adjoint`` at the dynamics layer.
+
+Specs are matched structurally by class name, so the identically-named
+classes from other libraries are accepted interchangeably.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import optimistix as optx
+
+from .k_step import KStepAdjoint
+
+
+def to_optimistix_adjoint(spec: Any) -> optx.AbstractAdjoint:
+    """Map an adjoint spec onto an ``optimistix.AbstractAdjoint``.
+
+    Mapping:
+
+    - ``ImplicitAdjoint()`` → ``optx.ImplicitAdjoint()`` — exact at a
+      converged fixed point, O(1) memory, one Hessian linear solve.
+    - ``RecursiveCheckpointAdjoint(checkpoints)`` →
+      ``optx.RecursiveCheckpointAdjoint(checkpoints)`` — exact,
+      recomputing.
+    - ``TruncatedAdjoint(k)`` →
+      [`KStepAdjoint(k)`][vardax.adjoints.KStepAdjoint] — warmup under
+      ``stop_gradient``, then ``k`` differentiable steps (``k=1`` is
+      [`OneStepAdjoint`][vardax.adjoints.OneStepAdjoint]).
+    - ``DirectAdjoint`` / ``BacksolveAdjoint`` → ``ValueError``: the
+      first is the plain unrolled default (pass
+      ``optx.RecursiveCheckpointAdjoint()`` or nothing), the second
+      only exists at the dynamics layer.
+
+    Args:
+        spec: A spec from ``pipekit_cycle.adjoints`` or any
+            structurally identical object. A ready-made
+            ``optx.AbstractAdjoint`` passes through unchanged.
+
+    Returns:
+        The corresponding optimistix adjoint instance.
+
+    Raises:
+        ValueError: for layer-inappropriate or unrecognised specs.
+
+    Examples:
+        >>> import optimistix as optx
+        >>> from pipekit_cycle.adjoints import TruncatedAdjoint
+        >>> from vardax.adjoints import to_optimistix_adjoint
+        >>> to_optimistix_adjoint(TruncatedAdjoint(k=3))
+        KStepAdjoint(k=3)
+        >>> isinstance(
+        ...     to_optimistix_adjoint(optx.ImplicitAdjoint()), optx.ImplicitAdjoint
+        ... )
+        True
+    """
+    if isinstance(spec, optx.AbstractAdjoint):
+        return spec
+    name = type(spec).__name__
+    if name == "ImplicitAdjoint":
+        return optx.ImplicitAdjoint()
+    if name == "RecursiveCheckpointAdjoint":
+        return optx.RecursiveCheckpointAdjoint(
+            checkpoints=getattr(spec, "checkpoints", None)
+        )
+    if name == "TruncatedAdjoint":
+        return KStepAdjoint(k=getattr(spec, "k", 1))
+    if name in ("DirectAdjoint", "BacksolveAdjoint"):
+        raise ValueError(
+            f"{name} does not apply at the inner-solve layer: DirectAdjoint is "
+            "the plain unrolled default (use optx.RecursiveCheckpointAdjoint() "
+            "or omit solver_adjoint), and BacksolveAdjoint only exists at the "
+            "dynamics layer (see pipekit_jax.DiffraxForwardModel)."
+        )
+    raise ValueError(f"Unrecognised adjoint spec: {spec!r}")

--- a/src/vardax/_src/adjoints/one_step.py
+++ b/src/vardax/_src/adjoints/one_step.py
@@ -27,14 +27,12 @@ adjoint is generalised for upstream contribution.
 
 from __future__ import annotations
 
-from collections.abc import Callable
 from typing import Any
 
-from jaxtyping import Array, PyTree
-import optimistix as optx
+from .k_step import KStepAdjoint
 
 
-class OneStepAdjoint(optx.AbstractAdjoint):
+class OneStepAdjoint(KStepAdjoint):
     """One-step differentiation (Bolte et al., 2023).
 
     Run ``K - 1`` warmup iterations of the inner solver with
@@ -62,26 +60,7 @@ class OneStepAdjoint(optx.AbstractAdjoint):
         [arXiv:2305.13768](https://arxiv.org/abs/2305.13768).
     """
 
-    def apply(
-        self,
-        primal_fn: Callable,
-        rewrite_fn: Callable,
-        inputs: PyTree,
-        tags: frozenset[object],
-    ) -> PyTree[Array]:
-        """Not used by vardax's custom learned solver — dispatch happens
-        in ``vardax._src.solver`` via ``isinstance`` on the adjoint type.
-
-        Implementing this method for upstream ``optimistix.minimise``
-        compatibility is tracked under the planned upstream
-        contribution (Decision D6).
-        """
-        raise NotImplementedError(
-            "OneStepAdjoint is currently a marker / strategy selector for the "
-            "FourDVarNet inner solver. Generic apply() support for "
-            "optimistix.minimise is planned as part of the upstream "
-            "contribution. Use it via FourDVarNet*(solver_adjoint=OneStepAdjoint())."
-        )
+    k: int = 1
 
     def __repr__(self) -> str:  # pragma: no cover - cosmetic
         return "OneStepAdjoint()"

--- a/src/vardax/_src/model.py
+++ b/src/vardax/_src/model.py
@@ -28,7 +28,7 @@ from jaxtyping import Array, Float, PRNGKeyArray
 import optimistix as optx
 
 from ._types import Batch1D, Batch2D, LSTMState1D, LSTMState2D
-from .adjoints import OneStepAdjoint
+from .adjoints import KStepAdjoint
 from .grad_mod import ConvLSTMGradMod1D, ConvLSTMGradMod2D
 from .priors import BilinAEPrior1D, BilinAEPrior2D
 
@@ -106,7 +106,7 @@ class FourDVarNet1D(eqx.Module):
         Dispatches on ``solver_adjoint`` to pick the differentiation
         path.
         """
-        if isinstance(self.solver_adjoint, OneStepAdjoint):
+        if isinstance(self.solver_adjoint, KStepAdjoint):
             return self._call_one_step(batch)
         if isinstance(self.solver_adjoint, optx.ImplicitAdjoint):
             return self._call_implicit(batch)
@@ -144,6 +144,7 @@ class FourDVarNet1D(eqx.Module):
             hidden_dim=self.grad_mod.hidden_dim,
             alpha=self.alpha,
             prior_weight=self.prior_weight,
+            k=getattr(self.solver_adjoint, "k", 1),
         )
 
     def _call_implicit(self, batch: Batch1D) -> Float[Array, "B T N"]:
@@ -239,7 +240,7 @@ class FourDVarNet2D(eqx.Module):
         Dispatches on ``solver_adjoint`` to pick the differentiation
         path.
         """
-        if isinstance(self.solver_adjoint, OneStepAdjoint):
+        if isinstance(self.solver_adjoint, KStepAdjoint):
             return self._call_one_step(batch)
         if isinstance(self.solver_adjoint, optx.ImplicitAdjoint):
             return self._call_implicit(batch)
@@ -275,6 +276,7 @@ class FourDVarNet2D(eqx.Module):
             hidden_dim=self.grad_mod.hidden_dim,
             alpha=self.alpha,
             prior_weight=self.prior_weight,
+            k=getattr(self.solver_adjoint, "k", 1),
         )
 
     def _call_implicit(self, batch: Batch2D) -> Float[Array, "B T H W"]:

--- a/src/vardax/_src/solver.py
+++ b/src/vardax/_src/solver.py
@@ -347,12 +347,16 @@ def one_step_solve_4dvarnet_1d(
     for _ in range(warmup_steps):
         state = solver_step_1d(state, batch, prior_fn, grad_mod_fn, alpha, prior_weight)
 
-    # detach the iterate so earlier steps don't contribute to the gradient
-    state = SolverState1D(
-        x=jax.lax.stop_gradient(state.x),
-        lstm=jax.lax.stop_gradient(state.lstm),
-        step=state.step,
-    )
+    # detach the iterate so earlier steps don't contribute to the
+    # gradient — but only when there was a warmup to detach: with
+    # k >= n_steps the solve is fully differentiable, including
+    # gradients with respect to the batch through the initial state.
+    if warmup_steps > 0:
+        state = SolverState1D(
+            x=jax.lax.stop_gradient(state.x),
+            lstm=jax.lax.stop_gradient(state.lstm),
+            step=state.step,
+        )
 
     # --- k differentiable steps ---
     for _ in range(live_steps):
@@ -403,12 +407,16 @@ def one_step_solve_4dvarnet_2d(
     for _ in range(warmup_steps):
         state = solver_step_2d(state, batch, prior_fn, grad_mod_fn, alpha, prior_weight)
 
-    # detach the iterate so earlier steps don't contribute to the gradient
-    state = SolverState2D(
-        x=jax.lax.stop_gradient(state.x),
-        lstm=jax.lax.stop_gradient(state.lstm),
-        step=state.step,
-    )
+    # detach the iterate so earlier steps don't contribute to the
+    # gradient — but only when there was a warmup to detach: with
+    # k >= n_steps the solve is fully differentiable, including
+    # gradients with respect to the batch through the initial state.
+    if warmup_steps > 0:
+        state = SolverState2D(
+            x=jax.lax.stop_gradient(state.x),
+            lstm=jax.lax.stop_gradient(state.lstm),
+            step=state.step,
+        )
 
     # --- k differentiable steps ---
     for _ in range(live_steps):

--- a/src/vardax/_src/solver.py
+++ b/src/vardax/_src/solver.py
@@ -313,12 +313,13 @@ def one_step_solve_4dvarnet_1d(
     hidden_dim: int,
     alpha: float = 1.0,
     prior_weight: float = 1.0,
+    k: int = 1,
 ) -> Float[Array, "B T N"]:
-    r"""Solve 4DVarNet-1D using one-step differentiation (Bolte et al., 2023).
+    r"""Solve 4DVarNet-1D using k-step differentiation (Bolte et al., 2023).
 
-    Runs ``n_steps - 1`` solver iterations with ``jax.lax.stop_gradient``
-    applied to the iterate, then performs a single final step through which
-    gradients flow.  This gives O(1) memory cost (matching implicit
+    Runs ``n_steps - k`` solver iterations with ``jax.lax.stop_gradient``
+    applied to the iterate, then performs ``k`` final steps through which
+    gradients flow.  This gives O(k) memory cost (k=1 matches implicit
     differentiation) while being as simple to implement as unrolled backprop.
 
     Reference:
@@ -329,18 +330,20 @@ def one_step_solve_4dvarnet_1d(
         batch: Observed data batch.
         prior_fn: Callable ``x -> x_prior``.
         grad_mod_fn: Callable ``(grad, x, lstm) -> (update, new_lstm)``.
-        n_steps: Total number of solver iterations (warmup = n_steps - 1,
-            then 1 differentiable step).
+        n_steps: Total number of solver iterations (warmup = n_steps - k,
+            then k differentiable steps).
         hidden_dim: Hidden dimension of the ConvLSTM gradient modulator.
         alpha: Step-size scaling factor.
         prior_weight: Weighting factor $\lambda$ for the prior cost term.
+        k: Number of trailing differentiable steps (clipped to n_steps).
 
     Returns:
         Final state estimate of shape ``(B, T, N)``.
     """
-    # --- warmup: run n_steps-1 steps without tracking gradients ---
+    # --- warmup: run n_steps-k steps without tracking gradients ---
     state = init_solver_state_1d(batch, hidden_dim)
-    warmup_steps = max(n_steps - 1, 0)
+    live_steps = min(max(k, 1), n_steps) if n_steps >= 1 else 0
+    warmup_steps = max(n_steps - live_steps, 0)
     for _ in range(warmup_steps):
         state = solver_step_1d(state, batch, prior_fn, grad_mod_fn, alpha, prior_weight)
 
@@ -351,8 +354,8 @@ def one_step_solve_4dvarnet_1d(
         step=state.step,
     )
 
-    # --- one differentiable step ---
-    if n_steps >= 1:
+    # --- k differentiable steps ---
+    for _ in range(live_steps):
         state = solver_step_1d(state, batch, prior_fn, grad_mod_fn, alpha, prior_weight)
 
     return state.x
@@ -366,12 +369,13 @@ def one_step_solve_4dvarnet_2d(
     hidden_dim: int,
     alpha: float = 1.0,
     prior_weight: float = 1.0,
+    k: int = 1,
 ) -> Float[Array, "B T H W"]:
-    r"""Solve 4DVarNet-2D using one-step differentiation (Bolte et al., 2023).
+    r"""Solve 4DVarNet-2D using k-step differentiation (Bolte et al., 2023).
 
-    Runs ``n_steps - 1`` solver iterations with ``jax.lax.stop_gradient``
-    applied to the iterate, then performs a single final step through which
-    gradients flow.  This gives O(1) memory cost (matching implicit
+    Runs ``n_steps - k`` solver iterations with ``jax.lax.stop_gradient``
+    applied to the iterate, then performs ``k`` final steps through which
+    gradients flow.  This gives O(k) memory cost (k=1 matches implicit
     differentiation) while being as simple to implement as unrolled backprop.
 
     Reference:
@@ -382,18 +386,20 @@ def one_step_solve_4dvarnet_2d(
         batch: Observed data batch.
         prior_fn: Callable ``x -> x_prior``.
         grad_mod_fn: Callable ``(grad, x, lstm) -> (update, new_lstm)``.
-        n_steps: Total number of solver iterations (warmup = n_steps - 1,
-            then 1 differentiable step).
+        n_steps: Total number of solver iterations (warmup = n_steps - k,
+            then k differentiable steps).
         hidden_dim: Hidden dimension of the ConvLSTM gradient modulator.
         alpha: Step-size scaling factor.
         prior_weight: Weighting factor $\lambda$ for the prior cost term.
+        k: Number of trailing differentiable steps (clipped to n_steps).
 
     Returns:
         Final state estimate of shape ``(B, T, H, W)``.
     """
-    # --- warmup: run n_steps-1 steps without tracking gradients ---
+    # --- warmup: run n_steps-k steps without tracking gradients ---
     state = init_solver_state_2d(batch, hidden_dim)
-    warmup_steps = max(n_steps - 1, 0)
+    live_steps = min(max(k, 1), n_steps) if n_steps >= 1 else 0
+    warmup_steps = max(n_steps - live_steps, 0)
     for _ in range(warmup_steps):
         state = solver_step_2d(state, batch, prior_fn, grad_mod_fn, alpha, prior_weight)
 
@@ -404,8 +410,8 @@ def one_step_solve_4dvarnet_2d(
         step=state.step,
     )
 
-    # --- one differentiable step ---
-    if n_steps >= 1:
+    # --- k differentiable steps ---
+    for _ in range(live_steps):
         state = solver_step_2d(state, batch, prior_fn, grad_mod_fn, alpha, prior_weight)
 
     return state.x

--- a/src/vardax/adjoints.py
+++ b/src/vardax/adjoints.py
@@ -7,13 +7,17 @@ for the design rationale (Decision D15).
 from vardax._src.adjoints import (
     AbstractAdjoint,
     ImplicitAdjoint,
+    KStepAdjoint,
     OneStepAdjoint,
     RecursiveCheckpointAdjoint,
+    to_optimistix_adjoint,
 )
 
 __all__ = [
     "AbstractAdjoint",
     "ImplicitAdjoint",
+    "KStepAdjoint",
     "OneStepAdjoint",
     "RecursiveCheckpointAdjoint",
+    "to_optimistix_adjoint",
 ]

--- a/tests/test_adjoint_strategies.py
+++ b/tests/test_adjoint_strategies.py
@@ -74,6 +74,23 @@ class TestKStepAdjoint:
             _grad_norm(m_full, batch_1d), _grad_norm(m_k3, batch_1d), rtol=1e-5
         )
 
+    def test_k_covering_solve_keeps_input_gradients(self, rng, batch_1d):
+        """k >= n_steps must not detach the initial state from the batch."""
+
+        def input_grad(adjoint):
+            model = _model(rng, batch_1d, adjoint, n_steps=3)
+
+            def loss(x):
+                batch = Batch1D(input=x, mask=batch_1d.mask, target=None)
+                return jnp.sum(model(batch) ** 2)
+
+            return jax.grad(loss)(batch_1d.input)
+
+        g_full = input_grad(optx.RecursiveCheckpointAdjoint())
+        g_k3 = input_grad(KStepAdjoint(k=3))
+        assert jnp.allclose(g_full, g_k3, rtol=1e-5)
+        assert not jnp.allclose(g_k3, 0.0)
+
     def test_intermediate_k_differs_from_both_ends(self, rng, batch_1d):
         g1 = _grad_norm(_model(rng, batch_1d, KStepAdjoint(k=1)), batch_1d)
         g2 = _grad_norm(_model(rng, batch_1d, KStepAdjoint(k=2)), batch_1d)

--- a/tests/test_adjoint_strategies.py
+++ b/tests/test_adjoint_strategies.py
@@ -1,0 +1,181 @@
+"""KStepAdjoint, the pipekit spec mapping, and diffrax-backed dynamics.
+
+The inner-solve layer of the shared adjoint-strategies design:
+``KStepAdjoint(k)`` generalises ``OneStepAdjoint`` (the ``k=1`` alias),
+``to_optimistix_adjoint`` interprets the ``pipekit_cycle.adjoints``
+vocabulary, and ``pipekit_jax.DiffraxForwardModel`` slots into
+``StrongFourDVar`` as a plain ``ForwardModel``.
+"""
+
+from __future__ import annotations
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+import lineax as lx
+import optimistix as optx
+import pytest
+
+import vardax as vdx
+from vardax._src._types import Batch1D
+from vardax.adjoints import KStepAdjoint, OneStepAdjoint, to_optimistix_adjoint
+
+
+@pytest.fixture
+def rng():
+    return jax.random.PRNGKey(0)
+
+
+@pytest.fixture
+def batch_1d(rng):
+    B, T, N = 2, 4, 8
+    return Batch1D(
+        input=jax.random.normal(rng, (B, T, N)),
+        mask=jnp.ones((B, T, N)),
+        target=None,
+    )
+
+
+def _model(rng, batch, adjoint, n_steps=3):
+    _, T, N = batch.input.shape
+    return vdx.FourDVarNet1D(
+        state_dim=N,
+        n_time=T,
+        latent_dim=8,
+        hidden_dim=16,
+        n_solver_steps=n_steps,
+        solver_adjoint=adjoint,
+        key=rng,
+    )
+
+
+def _grad_norm(model, batch):
+    def loss(m):
+        return jnp.sum(m(batch) ** 2)
+
+    grads = eqx.filter_grad(loss)(model)
+    leaves = [g for g in jax.tree.leaves(grads) if g is not None]
+    return jnp.sqrt(sum(jnp.sum(g**2) for g in leaves))
+
+
+class TestKStepAdjoint:
+    def test_k1_matches_one_step_exactly(self, rng, batch_1d):
+        m_one = _model(rng, batch_1d, OneStepAdjoint())
+        m_k1 = _model(rng, batch_1d, KStepAdjoint(k=1))
+        assert jnp.allclose(m_one(batch_1d), m_k1(batch_1d))
+        assert jnp.allclose(_grad_norm(m_one, batch_1d), _grad_norm(m_k1, batch_1d))
+
+    def test_k_equals_n_steps_matches_unrolled_gradient(self, rng, batch_1d):
+        """No warmup left to detach: identical to the unrolled default."""
+        m_full = _model(rng, batch_1d, optx.RecursiveCheckpointAdjoint(), n_steps=3)
+        m_k3 = _model(rng, batch_1d, KStepAdjoint(k=3), n_steps=3)
+        assert jnp.allclose(m_full(batch_1d), m_k3(batch_1d))
+        assert jnp.allclose(
+            _grad_norm(m_full, batch_1d), _grad_norm(m_k3, batch_1d), rtol=1e-5
+        )
+
+    def test_intermediate_k_differs_from_both_ends(self, rng, batch_1d):
+        g1 = _grad_norm(_model(rng, batch_1d, KStepAdjoint(k=1)), batch_1d)
+        g2 = _grad_norm(_model(rng, batch_1d, KStepAdjoint(k=2)), batch_1d)
+        g3 = _grad_norm(_model(rng, batch_1d, KStepAdjoint(k=3)), batch_1d)
+        assert not jnp.allclose(g1, g2)
+        assert not jnp.allclose(g2, g3)
+
+    def test_forward_values_identical_for_all_k(self, rng, batch_1d):
+        outs = [
+            _model(rng, batch_1d, KStepAdjoint(k=k))(batch_1d) for k in (1, 2, 3, 99)
+        ]
+        for out in outs[1:]:
+            assert jnp.allclose(outs[0], out)
+
+    def test_one_step_is_kstep_subclass(self):
+        assert isinstance(OneStepAdjoint(), KStepAdjoint)
+        assert OneStepAdjoint().k == 1
+
+    def test_invalid_k_rejected(self):
+        with pytest.raises(ValueError, match="k >= 1"):
+            KStepAdjoint(k=0)
+
+
+class TestToOptimistixAdjoint:
+    def test_pipekit_spec_mapping(self):
+        adjoints = pytest.importorskip("pipekit_cycle.adjoints")
+        mapped = to_optimistix_adjoint(adjoints.TruncatedAdjoint(k=4))
+        assert isinstance(mapped, KStepAdjoint)
+        assert mapped.k == 4
+        assert isinstance(
+            to_optimistix_adjoint(adjoints.ImplicitAdjoint()), optx.ImplicitAdjoint
+        )
+        assert isinstance(
+            to_optimistix_adjoint(adjoints.RecursiveCheckpointAdjoint(checkpoints=8)),
+            optx.RecursiveCheckpointAdjoint,
+        )
+
+    def test_raw_optimistix_passthrough(self):
+        raw = optx.ImplicitAdjoint()
+        assert to_optimistix_adjoint(raw) is raw
+
+    def test_layer_inappropriate_specs_rejected(self):
+        adjoints = pytest.importorskip("pipekit_cycle.adjoints")
+        with pytest.raises(ValueError, match="inner-solve layer"):
+            to_optimistix_adjoint(adjoints.BacksolveAdjoint())
+        with pytest.raises(ValueError, match="inner-solve layer"):
+            to_optimistix_adjoint(adjoints.DirectAdjoint())
+
+    def test_unknown_spec_rejected(self):
+        with pytest.raises(ValueError, match="Unrecognised"):
+            to_optimistix_adjoint(object())
+
+    def test_model_accepts_mapped_spec(self, rng, batch_1d):
+        adjoints = pytest.importorskip("pipekit_cycle.adjoints")
+        model = _model(
+            rng, batch_1d, to_optimistix_adjoint(adjoints.TruncatedAdjoint(k=2))
+        )
+        out = model(batch_1d)
+        assert out.shape == batch_1d.input.shape
+
+
+class TestDiffraxDynamics:
+    def test_strong_fourdvar_with_diffrax_forward(self, rng):
+        """DiffraxForwardModel is a pipekit ForwardModel — it slots straight in."""
+        pipekit_jax = pytest.importorskip("pipekit_jax")
+        pytest.importorskip("diffrax")
+
+        N = 4
+        fwd = pipekit_jax.DiffraxForwardModel(
+            vector_field=lambda t, y, args: -0.1 * y,
+            dt0=0.1,
+            dt=1.0,
+        )
+        model = vdx.StrongFourDVar(
+            forward=fwd,
+            obs_op=vdx.MaskedIdentity(),
+            prior_mean=jnp.zeros(N),
+            prior_cov_op=lx.IdentityLinearOperator(
+                jax.ShapeDtypeStruct((N,), jnp.float32)
+            ),
+            obs_cov_op=lx.IdentityLinearOperator(
+                jax.ShapeDtypeStruct((N,), jnp.float32)
+            ),
+        )
+        batch = Batch1D(
+            input=jax.random.normal(rng, (2, 1, N)),
+            mask=jnp.ones((2, 1, N)),
+            target=None,
+        )
+        out = model(batch)
+        assert out.shape == (2, N)
+        assert jnp.all(jnp.isfinite(out))
+
+    def test_adjoint_swap_is_configuration(self):
+        pipekit_jax = pytest.importorskip("pipekit_jax")
+        adjoints = pytest.importorskip("pipekit_cycle.adjoints")
+        pytest.importorskip("diffrax")
+
+        fwd = pipekit_jax.DiffraxForwardModel(
+            vector_field=lambda t, y, args: -y, dt0=0.1
+        )
+        swapped = fwd.with_adjoint(adjoints.DirectAdjoint())
+        assert swapped.adjoint == adjoints.DirectAdjoint()
+        y = jnp.ones(3)
+        assert jnp.allclose(fwd.step(y, 1.0), swapped.step(y, 1.0), atol=1e-5)


### PR DESCRIPTION
## Summary

**P2 of the unified adjoint-strategies design** (P0: jejjohnson/pipekit#46 ✅ merged · P1: jejjohnson/filterax#94): the inner-solve layer joins the shared vocabulary, and diffrax-backed dynamics slot into 4D-Var with zero vardax code changes.

### `KStepAdjoint(k)` — generalising `OneStepAdjoint` (decision a)
`n_steps − k` warmup iterations under `stop_gradient`, then `k` differentiable steps: O(k) backward memory, exact at a converged fixed point for any `k` (Bolte et al. 2023), and in the truncated-solver 4DVarNet regime larger `k` trades memory for a less biased gradient. `OneStepAdjoint` remains as the `k=1` subclass alias — existing code, `solver_adjoint=OneStepAdjoint()` call sites, and isinstance dispatch are all unchanged.

### `to_optimistix_adjoint(spec)` — the inner-solve-layer interpreter
Counterpart of `pipekit_jax.to_diffrax_adjoint` at the dynamics layer: `ImplicitAdjoint`/`RecursiveCheckpointAdjoint` map to their optimistix namesakes, `TruncatedAdjoint(k)` maps to `KStepAdjoint(k)`, raw optimistix adjoints pass through, and `DirectAdjoint`/`BacksolveAdjoint` are rejected as layer-inappropriate with pointers to the right layer.

### Diffrax-backed dynamics in 4D-Var (decision b — SDEs in scope upstream)
`pipekit_jax.DiffraxForwardModel` satisfies the `ForwardModel` protocol that `StrongFourDVar.forward` already consumes, so adaptive/implicit/SDE solvers and the whole diffrax adjoint menu drop straight in — verified by an integration test (gated on the optional pipekit-jax/diffrax install).

### Docs
Chapter 12 (Adjoint Methods) gains the shared-vocabulary section with the strategy-by-layer table (mirrored verbatim in pipekit and filterax); the training API page documents `KStepAdjoint` / `OneStepAdjoint` / `to_optimistix_adjoint`.

## Test plan
- [x] `KStepAdjoint(k=1)` ≡ `OneStepAdjoint` (outputs and gradients); `k = n_steps` ≡ the unrolled default; intermediate `k` differs at both ends; forward values identical for all `k`
- [x] Spec mapping: pipekit `TruncatedAdjoint(k)` → `KStepAdjoint(k)`, `ImplicitAdjoint`/`RecursiveCheckpointAdjoint` → optimistix, passthrough, layer-inappropriate and unknown specs rejected; a mapped spec drives `FourDVarNet1D` end to end
- [x] `StrongFourDVar` + `DiffraxForwardModel` integration; adjoint swap via `with_adjoint` is pure configuration
- [x] Full suite: 237 passed; ruff/format/ty clean; docstring gates pass; mkdocs build clean

https://claude.ai/code/session_018xVoXd1zzxK6cZGbSUgakd

---
_Generated by [Claude Code](https://claude.ai/code/session_018xVoXd1zzxK6cZGbSUgakd)_