### PR TITLE
feat: general reduced-basis operators backed by geonnax (split from #50)

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,10 +78,12 @@ from vardax.models import StrongFourDVar
 model = StrongFourDVar(
     forward=somax_model,
     obs_op=AveragingKernel(A=A, x_a=xa, h=h),
-    prior_mean=x_b, prior_cov_op=B_op, obs_cov_op=R_op,
+    prior_mean=x_b,
+    prior_cov_op=B_op,
+    obs_cov_op=R_op,
     minimiser=optx.NonlinearCG(rtol=1e-5),
-    minimiser_adjoint=optx.ImplicitAdjoint(),           # IFT at the optimum
-    forward_adjoint=dfx.BacksolveAdjoint(),             # constant-memory adjoint ODE
+    minimiser_adjoint=optx.ImplicitAdjoint(),  # IFT at the optimum
+    forward_adjoint=dfx.BacksolveAdjoint(),  # constant-memory adjoint ODE
 )
 ```
 
@@ -98,7 +100,7 @@ import pipekit_cycle as pc
 da_cycle = pc.DACycle(
     forward_model=somax_model,
     obs_op=AveragingKernel(...),
-    analysis_step=model.as_analysis_step(),   # any of the seven
+    analysis_step=model.as_analysis_step(),  # any of the seven
     obs_source=satellite_loader,
     n_steps=n_assimilation_windows,
 )
@@ -148,7 +150,7 @@ model = vdx.FourDVarNet1D(
     latent_dim=8,
     hidden_dim=16,
     n_solver_steps=15,
-    solver_adjoint=OneStepAdjoint(),   # Bolte et al. (2023), O(1) memory
+    solver_adjoint=OneStepAdjoint(),  # Bolte et al. (2023), O(1) memory
     key=jax.random.PRNGKey(0),
 )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ dependencies = [
     "optimistix>=0.1",
     "lineax>=0.1",
     "gaussx",
+    "geonnax",
     "pipekit",
     "pipekit-cycle",
 ]
@@ -188,6 +189,7 @@ ignore = [
     "F821",     # undefined name (jaxtyping dimension annotations)
     "PLR2004",  # magic value comparison
     "PLR0913",  # too many arguments
+    "PLR0917",  # too many positional arguments (same intent as PLR0913)
     "ISC001",   # conflicts with formatter
     "RUF002",   # ambiguous unicode characters in docstrings (math notation)
     "RUF022",   # __all__ not sorted (we use logical grouping)
@@ -223,6 +225,7 @@ output = "reports/coverage.xml"
 
 [tool.uv.sources]
 gaussx = { git = "https://github.com/jejjohnson/gaussx", rev = "cd6264c" }
+geonnax = { git = "https://github.com/jejjohnson/geonnax", rev = "5318173" }
 pipekit = { git = "https://github.com/jejjohnson/pipekit", subdirectory = "packages/pipekit" }
 pipekit-cycle = { git = "https://github.com/jejjohnson/pipekit", subdirectory = "packages/pipekit-cycle" }
 pipekit-jax = { git = "https://github.com/jejjohnson/pipekit", subdirectory = "packages/pipekit-jax" }

--- a/src/vardax/__init__.py
+++ b/src/vardax/__init__.py
@@ -37,6 +37,16 @@ from vardax._src.amortized import (
     RegressionHead,
     ScoreDiffusionHead,
 )
+from vardax._src.basis import (
+    CompositeBasis,
+    LinearBasis,
+    composite_basis,
+    eof_basis,
+    fourier_basis,
+    linear_basis,
+    rbf_basis,
+    wavelet_basis,
+)
 from vardax._src.costs import (
     decomposed_loss,
     obs_cost_1d,
@@ -96,6 +106,7 @@ from vardax._src.protocols import (
     ObservationOperator,
     PosteriorAdapter,
     Prior,
+    ReducedBasis,
 )
 from vardax._src.solver import (
     SolverState1D,
@@ -147,6 +158,16 @@ __all__ = [
     "ObservationOperator",
     "PosteriorAdapter",
     "Prior",
+    "ReducedBasis",
+    # Reduced bases (issue #49)
+    "CompositeBasis",
+    "LinearBasis",
+    "composite_basis",
+    "eof_basis",
+    "fourier_basis",
+    "linear_basis",
+    "rbf_basis",
+    "wavelet_basis",
     # Observation operators (Decision D9)
     "AveragingKernel",
     "InstrumentRegistry",

--- a/src/vardax/_src/basis/__init__.py
+++ b/src/vardax/_src/basis/__init__.py
@@ -1,0 +1,34 @@
+r"""Reduced-basis control-vector operators.
+
+Map a coefficient vector $X$ of length ``nbasis`` to a state increment
+$\Phi X$ on a grid, with a separable background term
+$\tfrac{1}{2} X^\top Q^{-1} X$. Used to parameterise a variational
+analysis increment in a low-dimensional space.
+
+One generic module, `LinearBasis`, covers every linear family; the
+family lives in the constructor that builds $\Phi$ (delegating the
+matrix math to ``geonnax.basis``): :func:`rbf_basis` (Gaussian /
+Wendland atoms), :func:`fourier_basis` (Laplacian eigenfunctions /
+HSGP), :func:`wavelet_basis` (Haar / Daubechies), :func:`eof_basis`
+(data-driven), and the :func:`linear_basis` escape hatch for any
+precomputed matrix. `CompositeBasis` stacks several bases into one
+control vector with a block-diagonal prior.
+
+Reference: MASSH `mapping/src/basis.py` (`set_basis`, `operg`,
+families `GAUSS*` / `BM` / `MIOST` / `WAVELET3D`).
+"""
+
+from .composite import CompositeBasis, composite_basis
+from .constructors import eof_basis, fourier_basis, rbf_basis, wavelet_basis
+from .linear import LinearBasis, linear_basis
+
+__all__ = [
+    "CompositeBasis",
+    "LinearBasis",
+    "composite_basis",
+    "eof_basis",
+    "fourier_basis",
+    "linear_basis",
+    "rbf_basis",
+    "wavelet_basis",
+]

--- a/src/vardax/_src/basis/composite.py
+++ b/src/vardax/_src/basis/composite.py
@@ -1,0 +1,69 @@
+r"""Concatenated reduced basis.
+
+Stacks several `ReducedBasis` components into a single control vector
+$X = [X_1, \ldots, X_C]$; ``operg`` sums the per-component increments,
+``prior_inv`` is block-diagonal.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import equinox as eqx
+import jax.numpy as jnp
+from jaxtyping import Array, Float
+
+
+class CompositeBasis(eqx.Module):
+    """Concatenate several reduced bases into one control vector.
+
+    Satisfies `vardax.protocols.ReducedBasis`. ``nbasis`` is the sum of
+    component sizes; ``operg`` slices ``X``, applies each component,
+    sums the per-grid increments; ``prior_inv`` slices ``X`` and
+    concatenates the per-component blocks. Components may mix families
+    (e.g. a broad `rbf_basis` layer plus a `wavelet_basis` detail
+    layer), provided their ``operg`` outputs share one grid shape.
+    """
+
+    components: tuple[Any, ...]
+    splits: tuple[int, ...] = eqx.field(static=True)
+
+    def operg(
+        self,
+        t: float,
+        X: Float[Array, " M"],
+        state: Float[Array, ...] | None = None,
+    ) -> Float[Array, ...]:
+        parts = self._split(X)
+        out = self.components[0].operg(t, parts[0], state)
+        for comp, part in zip(self.components[1:], parts[1:], strict=True):
+            out = out + comp.operg(t, part, state)
+        return out
+
+    def prior_inv(self, X: Float[Array, " M"]) -> Float[Array, " M"]:
+        parts = self._split(X)
+        blocks = [c.prior_inv(p) for c, p in zip(self.components, parts, strict=True)]
+        return jnp.concatenate(blocks)
+
+    @property
+    def nbasis(self) -> int:
+        return int(sum(c.nbasis for c in self.components))
+
+    def _split(self, X: Float[Array, " M"]) -> list[Float[Array, ...]]:
+        parts, start = [], 0
+        for cut in self.splits:
+            parts.append(X[start:cut])
+            start = cut
+        parts.append(X[start:])
+        return parts
+
+
+def composite_basis(*components: Any) -> CompositeBasis:
+    """Build a `CompositeBasis` from a sequence of `ReducedBasis` components."""
+    if not components:
+        raise ValueError("composite_basis requires at least one component.")
+    cuts, total = [], 0
+    for c in components[:-1]:
+        total += c.nbasis
+        cuts.append(total)
+    return CompositeBasis(components=tuple(components), splits=tuple(cuts))

--- a/src/vardax/_src/basis/constructors.py
+++ b/src/vardax/_src/basis/constructors.py
@@ -1,0 +1,252 @@
+r"""Family constructors for `LinearBasis`, delegating the matrix math to geonnax.
+
+Each constructor builds the geometry (grid points, domain box, …),
+calls the corresponding pure function in ``geonnax.basis`` to obtain
+the $(N, M)$ design matrix $\Phi$, attaches a diagonal prior variance,
+and returns a `LinearBasis`.
+
+Families:
+
+- :func:`rbf_basis` — placeable radial bumps (Gaussian or compactly
+  supported Wendland kernels). MASSH ``GAUSS*``-style local atoms.
+- :func:`fourier_basis` — Laplacian (Dirichlet) eigenfunctions on a
+  box; the prior variance can be a spectral density evaluated at the
+  eigenvalues (the HSGP construction).
+- :func:`wavelet_basis` — orthonormal Haar/Daubechies DWT basis.
+- :func:`eof_basis` — data-driven EOFs with explained-variance prior.
+
+Reference: MASSH `mapping/src/basis.py` (`set_basis`, `operg`,
+families `GAUSS*` / `BM` / `MIOST` / `WAVELET3D`).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from typing import Literal
+
+import geonnax.basis as _gnx
+import jax.numpy as jnp
+from jaxtyping import Array, Float
+import numpy as _np
+
+from .linear import LinearBasis, linear_basis
+
+
+def _grid_points(
+    grid_coords: Sequence[Float[Array, " _"]],
+) -> tuple[_np.ndarray, tuple[int, ...]]:
+    """Turn per-axis coordinate arrays into ``(N, d)`` points + grid shape."""
+    if len(grid_coords) < 1:
+        raise ValueError("grid_coords must contain at least one axis array.")
+    axes = [_np.asarray(a, dtype=float) for a in grid_coords]
+    for i, ax in enumerate(axes):
+        if ax.ndim != 1 or ax.size < 1:
+            raise ValueError(
+                f"grid_coords[{i}] must be a non-empty 1-D axis array; "
+                f"got shape {ax.shape}."
+            )
+    mesh = _np.meshgrid(*axes, indexing="ij")
+    pts = _np.stack([m.ravel() for m in mesh], axis=1)
+    return pts, tuple(ax.size for ax in axes)
+
+
+def rbf_basis(
+    grid_coords: Sequence[Float[Array, " _"]],
+    centers: Float[Array, "M d"],
+    *,
+    widths: float | Float[Array, " M"],
+    kernel: Literal["gaussian", "wendland_c2", "wendland_c4"] = "gaussian",
+    variance: float | Float[Array, " M"] = 1.0,
+) -> LinearBasis:
+    r"""Placeable radial-basis reduced basis (Gaussian or Wendland kernels).
+
+    Column $a$ of $\Phi$ is $\varphi_a(g) = K(\lVert g - c_a \rVert /
+    \ell_a)$ evaluated on the flattened grid. ``kernel="gaussian"``
+    reproduces the MASSH stationary Gaussian-RBF basis; the compactly
+    supported ``"wendland_c2"`` / ``"wendland_c4"`` kernels give columns
+    that are exactly zero past their width.
+
+    Args:
+        grid_coords: Per-axis 1-D coordinate arrays, e.g. ``(y_axis,
+            x_axis)`` for a 2-D grid. Any dimension ``d >= 1``.
+        centers: ``(M, d)`` array of atom centre locations.
+        widths: Scalar or per-atom ``(M,)`` width $\ell_a$ (Gaussian
+            length scale, or Wendland support radius); must be positive.
+        kernel: ``"gaussian"``, ``"wendland_c2"``, or ``"wendland_c4"``.
+        variance: Scalar or per-coefficient prior variance.
+
+    Returns:
+        `LinearBasis` with ``output_shape`` the grid shape and
+        ``nbasis == M``.
+    """
+    pts, grid_shape = _grid_points(grid_coords)
+    ndim = pts.shape[1]
+    cen = _np.asarray(centers, dtype=float)
+    if cen.ndim != 2 or cen.shape[1] != ndim:
+        raise ValueError(
+            f"centers must be (M, {ndim}) to match {ndim}-D grid_coords; "
+            f"got {cen.shape}."
+        )
+    m = cen.shape[0]
+    width_arr = _np.broadcast_to(_np.asarray(widths, dtype=float), (m,))
+    if _np.any(width_arr <= 0):
+        raise ValueError(
+            f"widths must be strictly positive; got min={float(width_arr.min())}."
+        )
+    phi = _gnx.rbf_basis(
+        jnp.asarray(pts),
+        jnp.asarray(cen),
+        jnp.asarray(width_arr),
+        kernel=kernel,
+    )
+    return linear_basis(phi, variance=variance, output_shape=grid_shape)
+
+
+def fourier_basis(
+    grid_coords: Sequence[Float[Array, " _"]],
+    num_modes: int | tuple[int, ...],
+    *,
+    boundary_scale: float = 1.25,
+    variance: float | Float[Array, " M"] = 1.0,
+    spectral_density: Callable[[Float[Array, " M"]], Float[Array, " M"]] | None = None,
+) -> LinearBasis:
+    r"""Laplacian-eigenfunction (Dirichlet/HSGP) reduced basis on a box.
+
+    Tensor-product sine eigenfunctions of $-\Delta$ on the (recentred,
+    slightly enlarged) grid bounding box. Passing ``spectral_density``
+    evaluates it at the Laplacian eigenvalues $\lambda_j$ and scales it
+    by ``variance`` — supply a kernel's spectral density to obtain the
+    Hilbert-space GP (HSGP) approximation of that kernel's prior with
+    amplitude ``variance``.
+
+    Args:
+        grid_coords: Per-axis 1-D coordinate arrays; any dimension
+            ``d >= 1``. Each axis must span a non-degenerate interval.
+        num_modes: Number of 1-D modes per axis; an ``int`` is broadcast
+            to all axes. Total ``nbasis`` is the product.
+        boundary_scale: Domain half-widths are the grid half-spans
+            times this factor (``>= 1``). The Dirichlet eigenfunctions
+            vanish on the box boundary, so a value ``> 1`` keeps the
+            basis expressive at the grid edges.
+        variance: Scalar or per-coefficient ``(M,)`` prior variance;
+            with ``spectral_density`` it acts as a scalar amplitude.
+        spectral_density: Optional callable mapping the eigenvalues
+            ``(M,)`` to per-mode prior power ``(M,)`` (HSGP prior).
+
+    Returns:
+        `LinearBasis` with ``output_shape`` the grid shape.
+    """
+    if boundary_scale < 1.0:
+        raise ValueError(f"boundary_scale must be >= 1, got {boundary_scale}.")
+    pts, grid_shape = _grid_points(grid_coords)
+    lo, hi = pts.min(axis=0), pts.max(axis=0)
+    half_span = (hi - lo) / 2.0
+    if _np.any(half_span <= 0):
+        raise ValueError(
+            "each grid_coords axis must span a non-degenerate interval "
+            f"(got half-spans {tuple(half_span.tolist())})."
+        )
+    centered = pts - (lo + hi) / 2.0
+    ndim = pts.shape[1]
+    half_widths = tuple(float(h) * boundary_scale for h in half_span)
+    modes = (
+        (int(num_modes),) * ndim
+        if isinstance(num_modes, int)
+        else tuple(int(k) for k in num_modes)
+    )
+    phi, eigvals = _gnx.fourier_basis(jnp.asarray(centered), modes, half_widths)
+    var = (
+        variance * spectral_density(eigvals)
+        if spectral_density is not None
+        else variance
+    )
+    return linear_basis(phi, variance=var, output_shape=grid_shape)
+
+
+def wavelet_basis(
+    grid_shape: int | tuple[int, ...],
+    *,
+    wavelet: str = "haar",
+    levels: int | None = None,
+    variance: float | Float[Array, " M"] = 1.0,
+) -> LinearBasis:
+    r"""Orthonormal wavelet (DWT) reduced basis on a periodic grid.
+
+    Haar / Daubechies synthesis basis: complete ($M = N$) and
+    orthonormal ($\Phi^\top \Phi = I$), so it is a multiscale
+    *re-parameterisation* of the grid — per-coefficient ``variance``
+    is the natural place to encode scale-dependent prior power.
+
+    Args:
+        grid_shape: ``n`` or ``(n,)`` for a 1-D grid, ``(ny, nx)`` for
+            2-D. Every extent must be a power of two ``>= 2``.
+        wavelet: ``"haar"``, ``"db2"``, or ``"db4"``.
+        levels: Decomposition levels; defaults to the full cascade.
+        variance: Scalar or per-coefficient prior variance.
+
+    Returns:
+        `LinearBasis` with ``output_shape == grid_shape`` and
+        ``nbasis == prod(grid_shape)``.
+    """
+    shape = (grid_shape,) if isinstance(grid_shape, int) else tuple(grid_shape)
+    if len(shape) == 1:
+        phi = _gnx.wavelet_basis_1d(int(shape[0]), wavelet=wavelet, levels=levels)
+    elif len(shape) == 2:
+        phi = _gnx.wavelet_basis_2d(
+            int(shape[0]), int(shape[1]), wavelet=wavelet, levels=levels
+        )
+    else:
+        raise ValueError(
+            f"wavelet_basis supports 1-D or 2-D grids; got {len(shape)}-D "
+            f"grid_shape {shape}."
+        )
+    return linear_basis(phi, variance=variance, output_shape=shape)
+
+
+def eof_basis(
+    data: Float[Array, "T N"],
+    n_modes: int,
+    *,
+    center: bool = True,
+    variance: float | Float[Array, " M"] | str = "explained",
+    output_shape: tuple[int, ...] | None = None,
+) -> LinearBasis:
+    r"""Data-driven EOF (PCA) reduced basis from a sample matrix.
+
+    The leading ``n_modes`` empirical orthogonal functions of ``data``
+    become the columns of $\Phi$. With ``variance="explained"`` the
+    prior variance of mode $a$ is its sample variance
+    $\sigma_a^2 / (T - 1)$, so the background term matches the
+    climatology of the training samples.
+
+    Args:
+        data: ``(T, N)`` sample matrix — ``T`` snapshots over the
+            flattened grid.
+        n_modes: Number of leading EOFs to keep.
+        center: Subtract the per-point sample mean before the SVD.
+        variance: ``"explained"`` (default), or a scalar / ``(M,)``
+            array overriding the prior variance.
+        output_shape: Grid shape to reshape increments to; must satisfy
+            ``prod(output_shape) == N``. Defaults to ``(N,)``.
+
+    Returns:
+        `LinearBasis` with orthonormal columns and ``nbasis == n_modes``.
+    """
+    data_arr = jnp.asarray(data)
+    phi, svals = _gnx.eof_basis(data_arr, n_modes, center=center)
+    if isinstance(variance, str):
+        if variance != "explained":
+            raise ValueError(
+                f'variance must be "explained", a scalar, or an array; '
+                f"got {variance!r}."
+            )
+        n_samples = int(data_arr.shape[0])
+        if n_samples < 2:
+            raise ValueError(
+                'variance="explained" needs at least 2 samples (T >= 2); '
+                f"got T={n_samples}."
+            )
+        var: float | Float[Array, " M"] = svals**2 / (n_samples - 1)
+    else:
+        var = variance
+    return linear_basis(phi, variance=var, output_shape=output_shape)

--- a/src/vardax/_src/basis/linear.py
+++ b/src/vardax/_src/basis/linear.py
@@ -1,0 +1,109 @@
+r"""Generic linear reduced basis.
+
+`LinearBasis` wraps *any* precomputed design matrix $\Phi \in
+\mathbb{R}^{N \times M}$ together with a diagonal prior
+$Q = \mathrm{diag}(\sigma^2)$: ``operg`` maps a coefficient vector
+$X$ to the state increment $(\Phi X)$ reshaped onto the grid, and
+``prior_inv`` applies $Q^{-1}$ for the separable background term
+$\tfrac{1}{2} X^\top Q^{-1} X$.
+
+The basis *family* (RBF, Fourier, wavelet, EOF, …) lives entirely in
+the constructor that builds $\Phi$ — see `vardax._src.basis.constructors`,
+which delegates the matrix math to ``geonnax.basis``.
+"""
+
+from __future__ import annotations
+
+import math
+
+import equinox as eqx
+import jax.numpy as jnp
+from jaxtyping import Array, Float
+import numpy as _np
+
+
+def _as_variance(variance: float | Float[Array, " M"], nbasis: int) -> _np.ndarray:
+    """Broadcast ``variance`` to ``(nbasis,)`` and require strict positivity."""
+    var_arr = _np.broadcast_to(_np.asarray(variance, dtype=float), (nbasis,)).astype(
+        _np.float32
+    )
+    if not _np.all(_np.isfinite(var_arr)):
+        raise ValueError("variance must be finite.")
+    if _np.any(var_arr <= 0):
+        raise ValueError(
+            f"variance must be strictly positive; got min={float(var_arr.min())}."
+        )
+    return var_arr
+
+
+class LinearBasis(eqx.Module):
+    r"""Generic linear reduced basis with a diagonal-$Q$ prior.
+
+    Build via :func:`linear_basis` (or a family constructor:
+    :func:`vardax.rbf_basis`, :func:`vardax.fourier_basis`,
+    :func:`vardax.wavelet_basis`, :func:`vardax.eof_basis`); direct
+    instantiation expects the precomputed ``phi`` ``(N, M)`` matrix,
+    ``variance`` ``(M,)``, and the grid ``output_shape`` with
+    ``prod(output_shape) == N``.
+
+    Satisfies `vardax.protocols.ReducedBasis` (`operg` / `prior_inv` /
+    `nbasis`). Stationary: ``operg`` ignores the ``t`` argument.
+    """
+
+    phi: Float[Array, "N M"]
+    variance: Float[Array, " M"]
+    output_shape: tuple[int, ...] = eqx.field(static=True)
+
+    def operg(
+        self,
+        t: float,
+        X: Float[Array, " M"],
+        state: Float[Array, ...] | None = None,
+    ) -> Float[Array, ...]:
+        r"""Apply $\Phi X$ — return the increment on ``output_shape``."""
+        return (self.phi @ X).reshape(self.output_shape)
+
+    def prior_inv(self, X: Float[Array, " M"]) -> Float[Array, " M"]:
+        r"""Apply $Q^{-1} X$ with diagonal $Q = \mathrm{diag}(\sigma^2)$."""
+        return X / self.variance
+
+    @property
+    def nbasis(self) -> int:
+        return int(self.phi.shape[1])
+
+
+def linear_basis(
+    phi: Float[Array, "N M"],
+    *,
+    variance: float | Float[Array, " M"] = 1.0,
+    output_shape: tuple[int, ...] | None = None,
+) -> LinearBasis:
+    r"""Build a `LinearBasis` from an arbitrary precomputed design matrix.
+
+    The escape hatch for basis families without a dedicated constructor:
+    any ``(N, M)`` matrix (spherical harmonics, Slepian, Gabor frames,
+    hand-rolled …) becomes a `ReducedBasis`.
+
+    Args:
+        phi: Design matrix of shape ``(N, M)``.
+        variance: Scalar or per-coefficient prior variance ``(M,)``.
+        output_shape: Grid shape the increment is reshaped to; must
+            satisfy ``prod(output_shape) == N``. Defaults to ``(N,)``.
+
+    Returns:
+        Configured `LinearBasis`.
+    """
+    phi_arr = jnp.asarray(phi)
+    if phi_arr.ndim != 2:
+        raise ValueError(f"phi must be 2-D (N, M); got shape {phi_arr.shape}.")
+    n, m = int(phi_arr.shape[0]), int(phi_arr.shape[1])
+    shape = (n,) if output_shape is None else tuple(int(s) for s in output_shape)
+    if math.prod(shape) != n:
+        raise ValueError(
+            f"prod(output_shape)={math.prod(shape)} does not match phi rows N={n}."
+        )
+    return LinearBasis(
+        phi=phi_arr,
+        variance=jnp.asarray(_as_variance(variance, m)),
+        output_shape=shape,
+    )

--- a/src/vardax/_src/protocols.py
+++ b/src/vardax/_src/protocols.py
@@ -1,7 +1,7 @@
 r"""Runtime-checkable protocols used across vardax.
 
 vardax re-exports the three core ``pipekit_cycle`` protocols
-(`ForwardModel`, `ObservationOperator`, `AnalysisStep`) and adds five
+(`ForwardModel`, `ObservationOperator`, `AnalysisStep`) and adds six
 vardax-specific protocols that ``pipekit-cycle`` doesn't name:
 
 - [`Prior`][vardax.Prior] — $\varphi: x \mapsto x_\text{prior}$
@@ -14,6 +14,8 @@ vardax-specific protocols that ``pipekit-cycle`` doesn't name:
 - [`Minimiser`][vardax.Minimiser] — wraps
   ``optimistix.AbstractMinimiser`` over vardax's cost-function
   interface
+- [`ReducedBasis`][vardax.ReducedBasis] —
+  $X \mapsto \Phi(t) X$ reduced-basis control-vector operator
 
 All protocols are ``@runtime_checkable`` so ``isinstance(obj, Protocol)``
 works for structural conformance checking — used by
@@ -137,6 +139,38 @@ class Minimiser(Protocol):
     ) -> Float[Array, ...]: ...
 
 
+@runtime_checkable
+class ReducedBasis(Protocol):
+    r"""Reduced-basis control-vector operator.
+
+    Maps a coefficient vector $X \in \mathbb{R}^M$ to a state increment
+    $\Phi(t) X$ on the grid, with a separable Gaussian background term
+    $\tfrac{1}{2} X^\top Q^{-1} X$.
+
+    Implementations: `LinearBasis` (any linear family — built via the
+    `rbf_basis` / `fourier_basis` / `wavelet_basis` / `eof_basis` /
+    `linear_basis` constructors) and `CompositeBasis`. Used by
+    variational analysis steps to parameterise the increment in a
+    low-dimensional space.
+
+    This protocol is defined in vardax for now; the plan is to upstream
+    it into ``pipekit_cycle.protocols`` so other algorithm libraries
+    can satisfy the same contract.
+
+    Members:
+        ``operg(t, X, state=None) -> increment``
+        ``prior_inv(X) -> Q⁻¹ X``
+        ``nbasis: int`` property
+    """
+
+    def operg(self, t: float, X: Any, state: Any = None) -> Any: ...
+
+    def prior_inv(self, X: Any) -> Any: ...
+
+    @property
+    def nbasis(self) -> int: ...
+
+
 __all__ = [
     # Re-exports from pipekit-cycle
     "AnalysisStep",
@@ -148,4 +182,5 @@ __all__ = [
     "Minimiser",
     "PosteriorAdapter",
     "Prior",
+    "ReducedBasis",
 ]

--- a/tests/test_basis.py
+++ b/tests/test_basis.py
@@ -1,0 +1,308 @@
+"""Tests for the reduced-basis operators (issue #49, split from PR #50).
+
+One protocol-conformance suite parametrized over every family
+constructor, plus per-family checks (bump geometry, compact support,
+spectral-density priors, orthonormality, explained variance).
+"""
+
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+import vardax as vdx
+from vardax import (
+    CompositeBasis,
+    LinearBasis,
+    ReducedBasis,
+    composite_basis,
+    linear_basis,
+)
+
+GRID_Y = np.linspace(0.0, 1.0, 8)
+GRID_X = np.linspace(0.0, 2.0, 16)
+GRID_SHAPE = (GRID_Y.size, GRID_X.size)
+
+
+def _make_rbf() -> LinearBasis:
+    centers = np.array([[0.5, 1.0], [0.2, 0.4], [0.9, 1.7]])
+    return vdx.rbf_basis((GRID_Y, GRID_X), centers, widths=0.1)
+
+
+def _make_fourier() -> LinearBasis:
+    return vdx.fourier_basis((GRID_Y, GRID_X), 3)
+
+
+def _make_wavelet() -> LinearBasis:
+    return vdx.wavelet_basis(GRID_SHAPE, wavelet="haar")
+
+
+def _make_eof() -> LinearBasis:
+    rng = np.random.default_rng(0)
+    data = rng.normal(size=(10, GRID_Y.size * GRID_X.size))
+    return vdx.eof_basis(data, 4, output_shape=GRID_SHAPE)
+
+
+def _make_linear() -> LinearBasis:
+    rng = np.random.default_rng(1)
+    phi = rng.normal(size=(GRID_Y.size * GRID_X.size, 5))
+    return linear_basis(phi, variance=2.0, output_shape=GRID_SHAPE)
+
+
+def _make_composite() -> CompositeBasis:
+    return composite_basis(_make_rbf(), _make_fourier())
+
+
+FAMILIES = {
+    "rbf": _make_rbf,
+    "fourier": _make_fourier,
+    "wavelet": _make_wavelet,
+    "eof": _make_eof,
+    "linear": _make_linear,
+    "composite": _make_composite,
+}
+
+
+@pytest.fixture(params=sorted(FAMILIES), ids=sorted(FAMILIES))
+def basis(request):
+    return FAMILIES[request.param]()
+
+
+class TestReducedBasisConformance:
+    """Every family satisfies the same `ReducedBasis` contract."""
+
+    def test_satisfies_protocol(self, basis):
+        assert isinstance(basis, ReducedBasis)
+
+    def test_operg_maps_coefficients_to_grid(self, basis):
+        X = jnp.ones((basis.nbasis,))
+        out = basis.operg(0.0, X)
+        assert out.shape == GRID_SHAPE
+
+    def test_operg_is_linear(self, basis):
+        rng = np.random.default_rng(2)
+        x1 = jnp.asarray(rng.normal(size=basis.nbasis), dtype=jnp.float32)
+        x2 = jnp.asarray(rng.normal(size=basis.nbasis), dtype=jnp.float32)
+        lhs = basis.operg(0.0, 2.0 * x1 + x2)
+        rhs = 2.0 * basis.operg(0.0, x1) + basis.operg(0.0, x2)
+        np.testing.assert_allclose(np.asarray(lhs), np.asarray(rhs), atol=1e-4)
+
+    def test_prior_inv_shape_and_positivity(self, basis):
+        X = jnp.ones((basis.nbasis,))
+        out = basis.prior_inv(X)
+        assert out.shape == (basis.nbasis,)
+        # Q is a positive diagonal, so X^T Q^{-1} X > 0 for X != 0.
+        assert float(jnp.sum(X * out)) > 0.0
+
+    def test_jit_traceable(self, basis):
+        @jax.jit
+        def call(X):
+            return basis.operg(0.0, X)
+
+        out = call(jnp.ones((basis.nbasis,)))
+        assert out.shape == GRID_SHAPE
+
+
+class TestRBF:
+    def test_single_coefficient_makes_a_bump(self):
+        centers = np.array([[0.5, 1.0], [0.2, 0.4]])
+        basis = vdx.rbf_basis((GRID_Y, GRID_X), centers, widths=0.05)
+        out = basis.operg(0.0, jnp.array([1.0, 0.0]))
+        iy, ix = np.unravel_index(int(jnp.argmax(out)), GRID_SHAPE)
+        assert abs(GRID_Y[iy] - 0.5) < 0.1
+        assert abs(GRID_X[ix] - 1.0) < 0.1
+
+    def test_wendland_has_compact_support(self):
+        centers = np.array([[0.5, 1.0]])
+        basis = vdx.rbf_basis(
+            (GRID_Y, GRID_X), centers, widths=0.2, kernel="wendland_c2"
+        )
+        out = np.asarray(basis.operg(0.0, jnp.array([1.0])))
+        gy, gx = np.meshgrid(GRID_Y, GRID_X, indexing="ij")
+        dist = np.hypot(gy - 0.5, gx - 1.0)
+        assert out[dist > 0.2].max() == 0.0
+        assert out[dist < 0.1].min() > 0.0
+
+    def test_per_atom_widths(self):
+        centers = np.array([[0.5, 1.0], [0.5, 1.0]])
+        basis = vdx.rbf_basis((GRID_Y, GRID_X), centers, widths=np.array([0.05, 0.5]))
+        narrow = basis.operg(0.0, jnp.array([1.0, 0.0]))
+        wide = basis.operg(0.0, jnp.array([0.0, 1.0]))
+        # The wider atom carries more total mass over the same grid.
+        assert float(jnp.sum(wide)) > float(jnp.sum(narrow))
+
+    def test_prior_inv_divides_by_variance(self):
+        centers = np.array([[0.5, 1.0], [0.2, 0.4]])
+        basis = vdx.rbf_basis((GRID_Y, GRID_X), centers, widths=0.05, variance=4.0)
+        out = basis.prior_inv(jnp.array([2.0, -3.0]))
+        np.testing.assert_allclose(np.asarray(out), [0.5, -0.75])
+
+    def test_works_in_one_dimension(self):
+        basis = vdx.rbf_basis((GRID_Y,), np.array([[0.5]]), widths=0.1)
+        assert basis.operg(0.0, jnp.array([1.0])).shape == (GRID_Y.size,)
+
+    def test_rejects_mismatched_centers(self):
+        with pytest.raises(ValueError, match=r"centers must be \(M, 2\)"):
+            vdx.rbf_basis((GRID_Y, GRID_X), np.zeros((3, 4)), widths=0.1)
+
+    def test_rejects_non_positive_widths(self):
+        with pytest.raises(ValueError, match="widths"):
+            vdx.rbf_basis((GRID_Y, GRID_X), np.array([[0.5, 1.0]]), widths=0.0)
+
+    def test_rejects_unknown_kernel(self):
+        with pytest.raises(ValueError, match="kernel"):
+            vdx.rbf_basis(
+                (GRID_Y, GRID_X), np.array([[0.5, 1.0]]), widths=0.1, kernel="cubic"
+            )
+
+    def test_rejects_non_positive_variance(self):
+        with pytest.raises(ValueError, match="variance must be strictly positive"):
+            vdx.rbf_basis(
+                (GRID_Y, GRID_X), np.array([[0.5, 1.0]]), widths=0.1, variance=0.0
+            )
+        with pytest.raises(ValueError, match="variance must be strictly positive"):
+            vdx.rbf_basis(
+                (GRID_Y, GRID_X),
+                np.array([[0.5, 1.0], [0.2, 0.4]]),
+                widths=0.1,
+                variance=np.array([1.0, -1.0]),
+            )
+
+
+class TestFourier:
+    def test_nbasis_is_product_of_modes(self):
+        basis = vdx.fourier_basis((GRID_Y, GRID_X), (3, 4))
+        assert basis.nbasis == 12
+
+    def test_spectral_density_prior(self):
+        """A spectral-density callable yields decreasing variance with
+        increasing eigenvalue (HSGP prior), scaled by ``variance``."""
+        basis = vdx.fourier_basis(
+            (GRID_Y, GRID_X),
+            3,
+            variance=2.0,
+            spectral_density=lambda lam: 1.0 / (1.0 + lam),
+        )
+        var = np.asarray(basis.variance)
+        assert var.shape == (9,)
+        assert var.max() <= 2.0
+        assert var.min() < var.max()
+
+    def test_boundary_scale_keeps_edges_nonzero(self):
+        """With ``boundary_scale > 1`` the increment need not vanish on
+        the grid edge rows/columns."""
+        basis = vdx.fourier_basis((GRID_Y, GRID_X), 3, boundary_scale=1.5)
+        out = np.abs(np.asarray(basis.operg(0.0, jnp.ones(9))))
+        assert out[0, :].max() > 1e-4
+        assert out[:, -1].max() > 1e-4
+
+    def test_rejects_boundary_scale_below_one(self):
+        with pytest.raises(ValueError, match="boundary_scale"):
+            vdx.fourier_basis((GRID_Y, GRID_X), 3, boundary_scale=0.5)
+
+    def test_rejects_degenerate_axis(self):
+        with pytest.raises(ValueError, match="non-degenerate"):
+            vdx.fourier_basis((GRID_Y, np.array([1.0])), 3)
+
+
+class TestWavelet:
+    def test_columns_are_orthonormal(self):
+        basis = vdx.wavelet_basis(16, wavelet="db2")
+        gram = np.asarray(basis.phi.T @ basis.phi)
+        np.testing.assert_allclose(gram, np.eye(16), atol=1e-5)
+
+    def test_complete_basis_on_2d_grid(self):
+        basis = vdx.wavelet_basis((8, 16))
+        assert basis.nbasis == 8 * 16
+        assert basis.output_shape == (8, 16)
+
+    def test_accepts_int_shorthand(self):
+        basis = vdx.wavelet_basis(8)
+        assert basis.output_shape == (8,)
+
+    def test_rejects_3d_grid(self):
+        with pytest.raises(ValueError, match="1-D or 2-D"):
+            vdx.wavelet_basis((4, 4, 4))
+
+    def test_rejects_non_power_of_two(self):
+        with pytest.raises(ValueError):
+            vdx.wavelet_basis(12)
+
+
+class TestEOF:
+    def test_explained_variance_matches_singular_values(self):
+        rng = np.random.default_rng(3)
+        data = rng.normal(size=(10, 32))
+        basis = vdx.eof_basis(data, 3)
+        centred = data - data.mean(axis=0, keepdims=True)
+        svals = np.linalg.svd(centred, compute_uv=False)[:3]
+        np.testing.assert_allclose(
+            np.asarray(basis.variance), svals**2 / 9.0, rtol=1e-4
+        )
+
+    def test_columns_are_orthonormal(self):
+        rng = np.random.default_rng(4)
+        basis = vdx.eof_basis(rng.normal(size=(10, 32)), 4)
+        gram = np.asarray(basis.phi.T @ basis.phi)
+        np.testing.assert_allclose(gram, np.eye(4), atol=1e-5)
+
+    def test_explicit_variance_overrides_explained(self):
+        rng = np.random.default_rng(5)
+        basis = vdx.eof_basis(rng.normal(size=(10, 32)), 2, variance=3.0)
+        np.testing.assert_allclose(np.asarray(basis.variance), [3.0, 3.0])
+
+    def test_rejects_explained_with_single_sample(self):
+        with pytest.raises(ValueError, match="at least 2 samples"):
+            vdx.eof_basis(np.ones((1, 32)), 1)
+
+    def test_rejects_unknown_variance_string(self):
+        with pytest.raises(ValueError, match="explained"):
+            vdx.eof_basis(np.ones((4, 32)), 1, variance="climatology")
+
+
+class TestLinearBasis:
+    def test_rejects_non_2d_phi(self):
+        with pytest.raises(ValueError, match="phi must be 2-D"):
+            linear_basis(jnp.ones((4,)))
+
+    def test_rejects_output_shape_mismatch(self):
+        with pytest.raises(ValueError, match="output_shape"):
+            linear_basis(jnp.ones((6, 2)), output_shape=(2, 2))
+
+    def test_default_output_shape_is_flat(self):
+        basis = linear_basis(jnp.ones((6, 2)))
+        assert basis.operg(0.0, jnp.ones(2)).shape == (6,)
+
+    def test_is_pytree_with_two_leaves(self):
+        basis = _make_rbf()
+        # `phi` + `variance` are JAX leaves; `output_shape` is static.
+        assert len(jax.tree_util.tree_leaves(basis)) == 2
+
+
+class TestComposite:
+    def test_nbasis_sums(self):
+        comp = composite_basis(_make_rbf(), _make_fourier())
+        assert comp.nbasis == 3 + 9
+
+    def test_operg_sums_components(self):
+        b1, b2 = _make_rbf(), _make_fourier()
+        comp = composite_basis(b1, b2)
+        X = jnp.arange(comp.nbasis, dtype=jnp.float32)
+        expected = b1.operg(0.0, X[:3]) + b2.operg(0.0, X[3:])
+        np.testing.assert_allclose(
+            np.asarray(comp.operg(0.0, X)), np.asarray(expected), atol=1e-5
+        )
+
+    def test_prior_inv_concatenates_blocks(self):
+        b1, b2 = _make_rbf(), _make_eof()
+        comp = composite_basis(b1, b2)
+        X = jnp.arange(1.0, comp.nbasis + 1.0)
+        out = comp.prior_inv(X)
+        np.testing.assert_allclose(np.asarray(out[:3]), np.asarray(b1.prior_inv(X[:3])))
+        np.testing.assert_allclose(np.asarray(out[3:]), np.asarray(b2.prior_inv(X[3:])))
+
+    def test_rejects_empty(self):
+        with pytest.raises(ValueError, match="at least one"):
+            composite_basis()


### PR DESCRIPTION
## Summary

Splits the reduced-basis piece out of #50 into its own PR and generalises it beyond Gaussian RBFs. The remaining #50 content (`InterpObs`, `Incremental4DVar`) is unaffected: `Incremental4DVar` only touches the basis through the `ReducedBasis` protocol members, so it rebases onto this with zero code changes.

### Design: one generic module, families live in constructors

The key observation from #50's `GaussianRBFBasis` is that nothing about it was Gaussian except the constructor — it stored a precomputed design matrix `phi (N, M)` plus a diagonal prior. This PR makes that explicit:

- **`LinearBasis`** — the single generic module: any `(N, M)` design matrix Φ + diagonal-Q prior. `operg(t, X)` = `(Φ X).reshape(output_shape)`, `prior_inv(X)` = `X / variance`, `nbasis` property. Stationary (`t` ignored); a future time-modulated wrapper satisfies the same protocol.
- **Family constructors** — thin adapters that build the geometry and delegate the matrix math to `geonnax.basis` (geonnax's docs explicitly place the `eqx.Module`/prior wrapper with the consuming library):
  - `rbf_basis` — placeable radial atoms: Gaussian **plus** compactly supported Wendland C2/C4 kernels, per-atom widths, any grid dimension. `kernel="gaussian"` reproduces #50's `gaussian_rbf_basis` (MASSH `GAUSS*`).
  - `fourier_basis` — Dirichlet/Laplacian eigenfunctions on the (recentred, `boundary_scale`-enlarged) grid box; optional `spectral_density` callable evaluated at the eigenvalues gives the HSGP prior for any kernel.
  - `wavelet_basis` — orthonormal Haar/Daubechies DWT basis, 1-D or 2-D (MASSH `WAVELET3D`-style multiscale control).
  - `eof_basis` — data-driven EOFs with `variance="explained"` prior from the sample spectrum (MASSH `BM`/`MIOST`-style).
  - `linear_basis` — escape hatch for any precomputed matrix (Slepian, spherical harmonics, Gabor, …).
- **`CompositeBasis`** — carried over from #50 unchanged; now stacks *mixed* families (e.g. broad RBF layer + wavelet detail layer) into one control vector with a block-diagonal prior.
- **`ReducedBasis` protocol** in `vardax.protocols` (`operg` / `prior_inv` / `nbasis`), vardax-local for now, slated to upstream into `pipekit_cycle.protocols`.

### Dependency

Adds **geonnax** as a hard dependency (git-pinned in `[tool.uv.sources]` like the other jejjohnson sources, rev `5318173` = post-v0.0.5 main). Its requirements (jax, equinox, jaxtyping, einx, einops) are effectively a subset of vardax's existing tree.

### Housekeeping

Current ruff (resolved fresh by CI via `ruff>=0.8.0`) newly enforces `PLR0917` and formats markdown code blocks, failing on 12 pre-existing violations in untouched files plus `README.md`. This PR adds `PLR0917` to the ignore list (same intent as the already-ignored `PLR0913`) and reformats the README code blocks so `ruff check .` / `ruff format --check .` are green.

## Test plan

62 new tests in `tests/test_basis.py`:

- **Conformance suite** parametrized over all six factories (rbf / fourier / wavelet / eof / linear / composite): `ReducedBasis` isinstance, coefficient→grid shapes, linearity of `operg`, positive prior quadratic form, `jit`-traceability.
- **Per-family**: RBF bump geometry + Wendland compact support + per-atom widths; spectral-density (HSGP) prior decay + `boundary_scale` edge behaviour; wavelet orthonormality (`Φᵀ Φ = I`) + power-of-two/3-D error paths; EOF explained-variance match against a NumPy SVD + orthonormal columns; composite sum/split invariants; construction error paths throughout.

- [x] 300 passing (was 238 on this base).
- [x] `uv run ruff check .` and `uv run ruff format --check .` clean.
- [x] `uv run ty check src/vardax` clean.
- [x] Public exports: `LinearBasis`, `CompositeBasis`, `ReducedBasis`, `linear_basis`, `rbf_basis`, `fourier_basis`, `wavelet_basis`, `eof_basis`, `composite_basis`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q4TQHUdKNmao8NxK55ExTY

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q4TQHUdKNmao8NxK55ExTY)_