### PR TITLE
docs: port mfourdvar physical-models, uncertainty, and OceanBench docs (Phase 3 of #13)

### DIFF
--- a/docs/19_physical_models.md
+++ b/docs/19_physical_models.md
@@ -1,0 +1,223 @@
+# Physical Models & ODE Priors
+
+Ported and condensed from the `mfourdvar` physical-models notes
+(`content/physical_models/`), rewired to the shipped vardax API.
+
+Chapter [3](03_dynamical_model.md) established the interface: vardax
+does not own dynamics, it owns the seam (`pipekit_cycle.ForwardModel`)
+and the adjoint composition. This chapter answers the two questions
+that seam leaves open in practice: **which physical model** should sit
+behind it at each stage of a project, and **how an ODE right-hand side
+becomes a prior** — the `DynamicalPrior` family (Decision D18), which
+turns "the state should obey the dynamics" into a differentiable cost
+term.
+
+## Choosing a testbed model
+
+Every assimilation method in this library is exercised against a
+ladder of physical models before it touches real data. Four selection
+criteria drive the choice of rung:
+
+- **Chaotic** — the model must exhibit sensitive dependence on initial
+  conditions, otherwise the assimilation problem is trivially easy and
+  says nothing about real geophysical use.
+- **Coupled** — for parameter-estimation and parameterisation-learning
+  studies, the model needs a term that can be withheld (a missing
+  forcing, or an unobserved fast state in a multi-level system).
+- **2-D spatiotemporal structure** — convolutional priors and the 2-D
+  model classes (`FourDVarNet2D`, `Batch2D`) need genuinely
+  two-dimensional fields.
+- **Scale** — eventually the method must survive state dimensions
+  where dense covariances are impossible and matrix-free structure
+  (chapter [13](13_posterior_covariance.md)) is mandatory.
+
+### The ladder
+
+| Model | State | Structure | Good for | Not for |
+|---|---|---|---|---|
+| Lorenz-63 | $\mathbb{R}^3$ | none | smoke tests, visualisation | anything spatial |
+| Lorenz-96 | $\mathbb{R}^N$ (ring) | 1-D periodic | prototyping, interpretability, low engineering cost | 2-D structure, scale |
+| Lorenz-96 two-level | $\mathbb{R}^{N + NJ}$ | 1-D, two timescales | coupled parameterisation learning, partial observation | 2-D structure |
+| Shallow water | $(h, u, v)$ on a grid | 2-D | wave dynamics, linearisation studies | eddy statistics |
+| Stacked quasi-geostrophy | $(q_k, \psi_k)$, $N_Z$ layers | 2-D, multi-layer | mesoscale turbulence, realistic SSH proxies | full-physics fidelity |
+| Ocean GCM (NEMO, MOM6, …) | full ocean state | 3-D | production reanalysis | differentiable end-to-end use |
+
+vardax ships the first two rungs (`Lorenz63`, `Lorenz96`,
+`simulate_lorenz63`, `simulate_lorenz96`); everything above them lives
+in dedicated model libraries (`somax` for geophysical fluids) and
+plugs in through `ForwardModel` — Decision D7.
+
+### Lorenz-96, one and two levels
+
+The single-level system on a periodic ring of $N$ variables,
+
+$$
+\frac{dx_i}{dt} = (x_{i+1} - x_{i-2})\,x_{i-1} - x_i + F,
+$$
+
+is chaotic for $F = 8$, cheap, and interpretable — the standard
+prototyping rung, used throughout the
+[Lorenz examples](15_lorenz_examples.md). Its two-level extension
+couples each slow variable $x_i$ to $J$ fast variables $y_j$:
+
+$$
+\begin{aligned}
+\frac{dx_i}{dt} &= (x_{i+1} - x_{i-2})\,x_{i-1} - x_i + F
+                  - \frac{h c}{b} \sum_{j} y_j, \\
+\frac{dy_j}{dt} &= -b c\,(y_{j+2} - y_{j-1})\,y_{j+1} - c\,y_j
+                  + \frac{h c}{b}\, x_{\lceil j/J \rceil}.
+\end{aligned}
+$$
+
+Observing only $x$ while the fast $y$ dynamics act as unresolved
+physics is the minimal faithful model of the parameterisation-learning
+problem: the coupling term is exactly the kind of "missing physics"
+a learnable ODE parameter $\theta$ (below) is meant to absorb.
+
+### Shallow water
+
+The linearised shallow-water system for height $h$ and velocities
+$(u, v)$ on a rotating plane,
+
+$$
+\begin{aligned}
+\partial_t h &+ H \left(\partial_x u + \partial_y v \right) = 0, \\
+\partial_t u &- f v = -g\, \partial_x h - \kappa u, \\
+\partial_t v &+ f u = -g\, \partial_y h - \kappa v,
+\end{aligned}
+$$
+
+is the first genuinely 2-D rung: wave propagation, geostrophic
+adjustment, and a clean linear operator to test tangent-linear /
+adjoint machinery (chapter [12](12_adjoint_methods.md)) against an
+analytic reference.
+
+### Stacked quasi-geostrophy
+
+For mesoscale ocean turbulence — the regime behind the
+[SSH application](21_oceanbench.md) — the workhorse is multi-layer QG
+in vorticity–streamfunction form, with $N_Z$ stacked isopycnal
+layers:
+
+$$
+\partial_t q_k + (u_k q_k)_x + (v_k q_k)_y = F_k + D_k,
+\qquad
+q = \frac{1}{f_0} \nabla_H^2 \psi - f_0 \mathbf{A} \psi
+    + \beta (y - y_0) + \tilde{\mathbf{D}},
+$$
+
+where $F_k$, $D_k$ are per-layer forcing and dissipation,
+$\tilde{\mathbf{D}}$ is dynamic topography, and $\mathbf{A}$ is the
+tri-diagonal layer-coupling matrix built from layer depths $H_k$ and
+reduced gravities $g_k'$. QG produces realistic eddy fields at a
+fraction of a GCM's cost, which is why the OSSE ground truths in
+chapter [21](21_oceanbench.md) are QG or NEMO simulations.
+
+### Ocean GCMs
+
+Full GCMs (NEMO, MOM6) anchor the top of the ladder, but converting
+such systems wholesale into differentiable models is a massive
+engineering effort (attempted rebuilds exist — e.g. Veros — and
+autodiff conversions of individual cores), and back-propagating
+through an entire GCM is rarely feasible or even useful in a learning
+loop. The practical route the mfourdvar notes converge on, and the one
+this library's boundaries assume, is **component surrogacy**: train
+fast differentiable emulators of individual subsystems and compose
+them behind `ForwardModel`, keeping the full GCM for producing
+training data and reference reanalyses.
+
+## From model to prior: the `DynamicalPrior` family
+
+A physical model enters the variational problem in one of two roles.
+As the **forward operator** it generates the trajectory that the
+observation term scores — the strong-constraint pattern of chapter
+[6](06_strong_4dvar.md). As a **prior** it penalises state sequences
+that disobey the dynamics while the state itself remains free — the
+weak-constraint pattern of chapter [7](07_weak_4dvar.md). The
+`DynamicalPrior` classes (ported from mfourdvar, Decision D18) package
+a diffrax-compatible ODE right-hand side
+$f(t, x; \theta)$ for both roles.
+
+### Two residuals
+
+`DynIncrements` scores local, one-step consistency: each state is
+integrated a single step and compared to its successor,
+
+$$
+R(u; \theta) = \sum_t \bigl\| u_{t+1} - \varphi_{\Delta t}(u_t; \theta) \bigr\|^2 .
+$$
+
+`DynTrajectory` scores global consistency: one rollout from the
+initial state, compared along the whole window,
+
+$$
+R(u; \theta) = \sum_t \bigl\| u_t - \varphi_t(u_0; \theta) \bigr\|^2 .
+$$
+
+The increment form tolerates model error accumulating over the window
+(weak-constraint flavour); the trajectory form is the hard-constraint
+propagation used by
+[`strong_variational_cost`](api/costs_priors.md).
+
+```python
+import jax.numpy as jnp
+from vardax import DynIncrements, DynTrajectory, Lorenz96
+
+rhs = Lorenz96(F=8.0)                     # any f(t, y, args) -> dy/dt
+ts = jnp.linspace(0.0, 0.5, 11)
+
+prior = DynIncrements(model=rhs)
+r = prior.loss(x, ts)                     # Σₜ ‖x_{t+1} − φ_Δt(x_t)‖²
+
+rollout = DynTrajectory(model=rhs)
+traj = rollout(x0, ts)                    # (T, N) trajectory from x0
+```
+
+Solver, step-size controller, and adjoint are pluggable
+(`solver=`, `stepsize=`, `adjoint=`); the defaults are `Tsit5` with an
+adaptive PID controller, falling back to a constant step for
+fixed-step solvers, and `RecursiveCheckpointAdjoint` for reverse-mode
+memory control — the same knobs discussed in chapter
+[12](12_adjoint_methods.md).
+
+### Learnable physics
+
+The ODE parameters $\theta$ thread through every call as `params`
+(diffrax `args`), and gradients flow through the solve:
+
+```python
+import jax
+
+prior = DynIncrements(model=rhs)
+grad_theta = jax.grad(lambda p: prior.loss(x, ts, params=p))(theta_0)
+```
+
+This is the parameter-estimation seam: fit $\theta$ (a forcing, a
+drag coefficient, a neural closure's weights) by minimising the
+dynamical residual of observed or analysed trajectories.
+
+### One prior, three seams
+
+The same object plugs into all three integration points of the
+library:
+
+```python
+# 1. TemporalPrior — native two-argument seam
+prior.loss(x, ts)
+
+# 2. Prior — bind the time grid, drop into the weak-constraint cost
+from vardax import variational_cost
+cost = variational_cost(x, batch, jax.vmap(prior.bind(ts)))
+
+# 3. pipekit ForwardModel — drive strong 4DVar or a DA cycle
+fwd = prior.as_forward_model(dt=0.05)     # .step / .dt / .state_signature
+```
+
+`bind(ts)` closes over the window's time grid so the dynamical prior
+satisfies the one-argument [`Prior`](api/protocols.md) protocol —
+turning the $\lVert x - \varphi(x)\rVert^2$ term of
+[`variational_cost`](api/costs_priors.md) into a weak-constraint
+dynamical residual with no API change. `as_forward_model(dt)` adapts
+the wrapped ODE to `pipekit_cycle.ForwardModel` (autonomous dynamics
+assumed), so the same physics can serve as the forward operator of
+[`StrongFourDVar`](06_strong_4dvar.md) or a `pipekit_cycle.DACycle`.

--- a/docs/20_uncertainty.md
+++ b/docs/20_uncertainty.md
@@ -1,0 +1,128 @@
+# Uncertainty Quantification
+
+Consolidated from the `mfourdvar` uncertainty notes
+(`content/uncertainty/`), which sketched the taxonomy below as an
+outline; this chapter fills it in and maps each branch to the vardax
+machinery that implements it.
+
+Chapter [13](13_posterior_covariance.md) covers *how* to compute a
+posterior covariance; this chapter is the map of *what is uncertain in
+the first place* — where stochasticity enters a variational
+assimilation system, and which lever addresses which source.
+
+## Three kinds of uncertainty
+
+- **Aleatoric** — irreducible randomness in the measurement process:
+  sensor noise, representativeness error, sampling gaps. More data of
+  the same kind does not remove it; it belongs in the likelihood
+  ($R$).
+- **Epistemic** — reducible ignorance about the system: imperfect
+  model physics, unknown parameters, limited training data. More
+  information (observations, better physics, more training) shrinks
+  it; it belongs in priors and posteriors.
+- **Intrinsic variability** — chaotic sensitivity of the dynamics
+  itself. Even a perfect model with perfect parameters diverges from
+  truth under infinitesimal initial-condition error; it bounds
+  predictability (forecast horizon) rather than estimation quality.
+
+The mfourdvar notes organise the *loci* of these uncertainties into
+four groups — data, model, parameters, estimation — which map onto
+vardax as follows.
+
+## Uncertain data
+
+The likelihood side. Observation error enters the cost through the
+observation-error covariance $R$ (chapter
+[2](02_observation_model.md)); real data additionally arrive with
+gaps.
+
+- **Error covariance** — every analysis method takes an `obs_cov_op`
+  ($R$ as a `lineax` operator); per-instrument $R$ blocks compose
+  through [`MultiInstrumentFusion`](11_observation_operators.md).
+- **Gaps and NaNs** — real products encode missing data as `NaN`
+  rather than a clean mask; the `nan_to_num` flag of
+  [`obs_cost_1d` / `obs_cost_2d`](api/costs_priors.md) and the
+  NaN-stripping analysis steps keep gradients finite (ported from
+  mfourdvar's NaN-safe observation operator).
+- **Augmentation and latent inputs** — the mfourdvar notes flag two
+  learning-side treatments: perturbing inputs with samples of the
+  observation noise during training, and letting an encoder treat the
+  clean field as a latent variable behind noisy inputs. In vardax
+  these live in the training loop (noise injection via
+  `vardax.utils` noise helpers) and in the amortized encoder heads
+  (chapter [10](10_amortized_inference.md)) respectively.
+
+## Uncertain model
+
+The dynamics side. A forward model is wrong in ways that range from
+"ignore it" to "model it":
+
+- **Deterministic (perfect-model)** — strong-constraint 4DVar
+  (chapter [6](06_strong_4dvar.md)) treats $M_t$ as exact; all model
+  error is silently folded into the initial-condition posterior.
+- **Additive model error** — weak-constraint 4DVar (chapter
+  [7](07_weak_4dvar.md)) promotes per-step error terms
+  $\boldsymbol{\eta}_t$ to control variables with their own covariance
+  $Q$; the dynamical-residual priors
+  ([`DynIncrements`](19_physical_models.md)) are the functional
+  version of the same idea — dynamics as a soft penalty rather than a
+  hard constraint.
+- **Fully Bayesian** — placing distributions over the model structure
+  itself is out of vardax's scope; the pragmatic surrogate is
+  ensembles over model variants, scored through the same analysis
+  seams.
+
+## Uncertain parameters
+
+Between data and model sit the parameters $\theta$ — ODE forcings,
+closure coefficients, neural-prior weights:
+
+- **Deterministic point estimates** — fit $\theta$ by gradient
+  descent through the solve
+  ([`DynamicalPrior.loss(..., params=θ)`](19_physical_models.md) is
+  differentiable in $\theta$).
+- **Probabilistic** — the amortized family (chapter
+  [10](10_amortized_inference.md)) returns distributions, not points:
+  `ConditionalFlowHead` for flow-based posteriors, with the
+  reverse-SDE `ScoreDiffusionHead` stubbed for multimodal cases.
+- **Approximate Bayesian** — the mfourdvar outline lists dropout and
+  deep ensembles. Neither needs library support beyond what exists:
+  ensembles are `jax.vmap` over `PRNGKey`s at construction time, and
+  their spread feeds the ensemble posterior adapter below.
+
+## Uncertain estimation
+
+The output side: attaching error bars to the analysis itself.
+
+- **Curvature-based** — the posterior adapters of chapter
+  [13](13_posterior_covariance.md): `LaplaceCovariance` (inverse
+  Hessian at the mode), `GaussNewtonHessian` (drops second-order
+  terms), both matrix-free via `lineax`.
+- **Monte Carlo / ensemble** — `EnsembleCovariance` estimates the
+  posterior spread from an ensemble of analyses (perturbed
+  observations, perturbed parameters, or both).
+- **Amortized** — the heads of chapter
+  [10](10_amortized_inference.md) emit $q_\phi(x \mid y)$ directly.
+- **Conformal prediction** — distribution-free calibrated intervals
+  wrapped around any point estimator; listed in the mfourdvar outline
+  as future work and deliberately left outside vardax (it is a
+  post-processing wrapper, not an assimilation component).
+
+## Trust, but verify
+
+Every uncertainty estimate above is an approximation, and the library
+treats "is it calibrated?" as a first-class question. The validation
+gates of the [six-step cycle](14_six_step_cycle.md) are the
+enforcement mechanism:
+
+```python
+from vardax import (
+    simulation_based_calibration,   # SBC ranks must be uniform
+    assert_posterior_agreement,     # two adapters must agree
+    assert_adjoint_calibrated,      # cheap adjoint must track exact grad
+)
+```
+
+Run simulation-based calibration before believing any posterior; if
+the rank histogram is not uniform, the reported uncertainty is
+mis-calibrated regardless of how principled its derivation looked.

--- a/docs/21_oceanbench.md
+++ b/docs/21_oceanbench.md
@@ -1,0 +1,131 @@
+# OceanBench: SSH Applications
+
+Ported and condensed from the `mfourdvar` OceanBench notes
+(`content/oceanbench/`); the flagship application context that
+motivated this library.
+
+> "OceanBench is a framework for co-designing learning-driven
+> high-level experiments from ocean models, reanalysis, and
+> observations. It consists of an end-to-end framework for piping data
+> from its raw form to an ML-ready state and from model outputs to
+> interpretable quantities."
+
+Chapter [16](16_ssh_example.md) walks through *one* SSH
+reconstruction end-to-end; this chapter is the surrounding benchmark
+context — where the data come from, how the experiment ladder is
+structured, and which OceanBench task each vardax component serves.
+
+## Why a benchmark framework
+
+The ML method is the smallest part of an operational chain. The parts
+that dominate the effort are getting raw ocean data into an ML-ready
+form, evaluating a proposed tool against operationally meaningful
+metrics, and inserting it into an operational pipeline —
+reproducibly, so that non-experts in operations can contribute a
+method without rebuilding the plumbing. OceanBench standardises that
+chain (raw observations / simulations / reanalyses → ML-ready patches
+→ method → interpretable metrics); vardax slots in as the *method*
+box, with `pipekit` supplying the pipeline substrate
+([design/pipekit_composition.md](design/pipekit_composition.md)).
+
+## Data
+
+Three families of product, all reachable through the Copernicus
+Marine Data Store:
+
+- **Observations** — along-track satellite altimetry (NADIR
+  pencil-beam tracks; SWOT wide-swath), plus in-situ profiles.
+  Sparse, gappy, noisy: the `y` of every cost in this library.
+- **Reanalysis** — GLORYS12V1, the CMEMS global eddy-resolving
+  reanalysis at $1/12^\circ$ with 50 vertical levels (1993–2020),
+  assimilating along-track altimetry, SST, sea ice, and in-situ
+  T/S profiles. Reanalyses blend model and observations, which makes
+  them the standard training target for learned methods.
+- **Free-run simulation** — NEMO runs without assimilation; the
+  ground truth generator for observing-system simulation experiments
+  (OSSE), where "truth" must be known exactly.
+
+Two pragmatic ladders recur throughout: **regions** (Gulf Stream →
+Mediterranean → North Atlantic → global) and **frequency** (daily maps
+before hourly), each solving a drastically simpler problem before
+scaling up — with transfer learning carrying weights up the rungs.
+
+## The experiment ladder
+
+**OSSE** (observing-system *simulation* experiments) sample synthetic
+observations from a known simulated truth, so reconstruction error is
+exactly measurable. The editions add data sources incrementally —
+ablate to learn which source carries the signal:
+
+| Edition | Observations | What it tests |
+|---|---|---|
+| OSSE NADIR | simulated NADIR altimetry tracks (from a NEMO run) | baseline sparse-track interpolation |
+| OSSE SWOT | NADIR + SWOT swaths | higher spatial resolution, lower temporal; much higher data volume |
+| OSSE NADIR + SWOT + SST | + sea-surface temperature | multivariate synergy — SSH and SST are dynamically coupled, and SST is abundant with few gaps |
+
+**OSE** (observing-system experiments) then rerun the winning
+configuration on *real* NADIR altimetry, where truth is unknown and
+evaluation falls back to withheld tracks and physical diagnostics.
+
+## Tasks
+
+### SSH interpolation
+
+Fill the gaps between altimeter tracks to produce daily gap-free SSH
+maps — the first OceanBench edition, and the task chapter
+[16](16_ssh_example.md) implements three ways (OI baseline,
+`IncrementalFourDVar`, learned `FourDVarNet`). The learned
+configuration in brief:
+
+```python
+import jax
+from vardax import Batch2D, FourDVarNet2D
+
+model = FourDVarNet2D(
+    n_time=5,                # T: days in the assimilation window
+    height=128,              # H, W: regional lon-lat patch
+    width=128,
+    latent_dim=32,
+    hidden_dim=48,
+    n_solver_steps=15,
+    key=jax.random.PRNGKey(0),
+)
+
+batch = Batch2D(
+    input=ssh_tracks,        # (B, T, H, W), zero-filled gaps
+    mask=track_mask,         # 1 on-track, 0 in gaps
+    target=ssh_truth,        # OSSE only
+)
+ssh_maps = model(batch)      # (B, T, H, W) gap-free reconstruction
+```
+
+Real altimetry products carry `NaN` in the gaps rather than zeros —
+strip them with the NaN-safe observation costs
+([`obs_cost_2d(..., nan_to_num=True)`](api/costs_priors.md)) or a
+masking preprocessing step, per chapter [20](20_uncertainty.md).
+
+### SSH forecasting
+
+Propagate currently-assimilated maps forward in time (1 / 5 / 10-day
+leads), training on historical reanalysis so the model captures the
+blended physics-plus-observations signal. In vardax terms this is the
+`ForwardModel` seam's job: a learned surrogate trained on GLORYS
+drives a [`DACycle`](api/cycle.md) forward between assimilation
+windows, and the analysis methods correct it as observations arrive.
+
+### SSH surrogates
+
+Learn the flow map itself — emulate the simulation at 1 / 6 / 12 /
+24-hour steps from free-run data. Surrogates are the component-level
+answer to non-differentiable GCMs (chapter
+[19](19_physical_models.md)): once trained, a surrogate is a
+differentiable `ForwardModel`, usable as the forward operator of
+[`StrongFourDVar`](06_strong_4dvar.md) or wrapped as a dynamical
+prior.
+
+## Status
+
+The interpolation task is fully exercised by the code in chapter
+[16](16_ssh_example.md) and the 2-D demo notebook; a dedicated
+OceanBench SSH-interpolation tutorial notebook is deferred (tracked
+with the Phase-3 tutorial issues of the mfourdvar migration epic).

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,7 +16,7 @@
 This directory contains documentation for the vardax library, in two
 layers:
 
-- **Mathematical reference** (this directory, 17 chapters) — the
+- **Mathematical reference** (this directory, 21 chapters) — the
   equations, algorithms, and pseudocode behind every analysis method.
 - **Design docs** ([`design/`](design/)) — architecture, API
   contracts, ecosystem boundaries, decision log.
@@ -57,7 +57,7 @@ layers:
 14. [Six-Step Inference Cycle](14_six_step_cycle.md) — methodology for
     the research-to-operations arc
 
-### End-to-end examples (chapters 15–17)
+### End-to-end examples (chapters 15–18)
 
 15. [Lorenz Examples](15_lorenz_examples.md) — L63 / L96 walkthroughs
     with all seven methods
@@ -65,6 +65,20 @@ layers:
     with `OI`, `IncrementalFourDVar`, `FourDVarNet` side-by-side
 17. [Methane Single-Overpass](17_methane_example.md) — multi-instrument
     inversion with `plumax` + `IncrementalFourDVar`
+18. [Latent Variational DA](18_latent_da.md) — assimilation in a
+    learned latent space (Decision D17)
+
+### Applications & foundations (chapters 19–21, ported from mfourdvar)
+
+19. [Physical Models & ODE Priors](19_physical_models.md) — the
+    testbed-model ladder (L63/L96 → SW/QG → GCM) and the
+    `DynamicalPrior` family (Decision D18)
+20. [Uncertainty Quantification](20_uncertainty.md) — where
+    stochasticity enters (data, model, parameters, estimation) and
+    which vardax lever addresses each source
+21. [OceanBench SSH Applications](21_oceanbench.md) — the benchmark
+    context: data products, OSSE/OSE ladder, interpolation /
+    forecasting / surrogate tasks
 
 ### Reference
 
@@ -83,7 +97,7 @@ contents and reading order. Recommended entry points:
 - [`design/boundaries.md`](design/boundaries.md) — ownership map,
   Epics 0–13 roadmap
 - [`design/decisions.md`](design/decisions.md) — design decisions
-  D1–D16
+  D1–D19
 - [`design/api/`](design/api/) — protocol + class contracts by layer
 - [`design/examples/`](design/examples/) — patterns and use case
   walkthroughs

--- a/docs/api/utils.md
+++ b/docs/api/utils.md
@@ -17,7 +17,7 @@ one-step increment losses.
     options:
       show_root_heading: false
       show_root_toc_entry: false
-      members: [simulate_lorenz63, simulate_lorenz96, time_patches]
+      members: [Lorenz63, Lorenz96, simulate_lorenz63, simulate_lorenz96, time_patches]
 
 ## Validation gates
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -99,6 +99,10 @@ nav:
           - 16. SSH Reconstruction: 16_ssh_example.md
           - 17. Methane Single-Overpass: 17_methane_example.md
           - 18. Latent Variational DA: 18_latent_da.md
+      - Applications & Foundations:
+          - 19. Physical Models & ODE Priors: 19_physical_models.md
+          - 20. Uncertainty Quantification: 20_uncertainty.md
+          - 21. OceanBench SSH Applications: 21_oceanbench.md
       - Reference:
           - Notation: notation.md
           - References: references.md

--- a/src/vardax/__init__.py
+++ b/src/vardax/__init__.py
@@ -127,7 +127,12 @@ from vardax._src.training import (
     train_loss_fn,
     train_step,
 )
-from vardax._src.utils.dynamical_systems import simulate_lorenz63, simulate_lorenz96
+from vardax._src.utils.dynamical_systems import (
+    Lorenz63,
+    Lorenz96,
+    simulate_lorenz63,
+    simulate_lorenz96,
+)
 from vardax._src.utils.patches import time_patches
 from vardax._src.utils.validation import (
     assert_adjoint_calibrated,
@@ -246,6 +251,8 @@ __all__ = [
     "train_loss_fn",
     "train_step",
     # Dynamical systems
+    "Lorenz63",
+    "Lorenz96",
     "simulate_lorenz63",
     "simulate_lorenz96",
     "time_patches",


### PR DESCRIPTION
## Overview

Phase 3 (docs) of the mfourdvar → vardax migration epic (#13): port the three documentation sets from `mfourdvar/content/` into the vardax math-reference as chapters 19–21. Tutorial notebooks (#23–#25) are deliberately left for a later PR.

Closes #20, closes #21, closes #22.

## Changes

### Chapter 19 — Physical Models & ODE Priors (#20)
- The testbed-model ladder with selection criteria (chaotic / coupled / 2-D / scale): Lorenz-63/96, two-level L96, linear shallow water, stacked QG (vorticity–streamfunction form), and the ocean-GCM component-surrogacy argument, condensed from `content/physical_models/`.
- The `DynamicalPrior` section the issue asked for as a second page is folded in as the chapter's second half (the issue's `13_`/`14_` numbering predates the current 18-chapter tree): increment vs trajectory residuals with math, learnable ODE parameters via `params`, and the three integration seams (`TemporalPrior`, `bind → Prior`, `as_forward_model → pipekit ForwardModel`).

### Chapter 20 — Uncertainty Quantification (#21)
- The mfourdvar uncertainty pages were skeletal outlines (headings, almost no prose), so this chapter fills in their taxonomy — aleatoric/epistemic/intrinsic across the four loci (data, model, parameters, estimation) — against the shipped API: `nan_to_num` costs, weak-constraint η, posterior adapters, amortized heads, SBC validation gates.

### Chapter 21 — OceanBench SSH Applications (#22)
- Benchmark context from `content/oceanbench/`: Copernicus/GLORYS data products, the region/frequency ladders, the OSSE (NADIR → SWOT → +SST) / OSE experiment structure, and the three tasks (interpolation, forecasting, surrogates) mapped to vardax seams.
- Includes the `FourDVarNet2D` SSH-interpolation snippet requested by the issue (checked against the real constructor signature) and links to the existing chapter 16 walkthrough. The stretch notebook is deferred with the tutorial issues.

### Wiring
- New "Applications & Foundations" nav group in `mkdocs.yml`; `docs/README.md` ToC extended (also fixes stale entries: chapter 18 was unlisted, "17 chapters" → 21, "D1–D16" → D1–D19).
- `Lorenz63` / `Lorenz96` vector-field classes exported so chapter 19's example imports from the public namespace; added to the utils API page.

## Verification

- `mkdocs build` passes; all three chapters render, and mkdocstrings resolves every newly listed API member (`TemporalPrior`, `strong_variational_cost`, `Lorenz63`, …).
- Full suite: **279 passed, 2 skipped**; `ruff check` / `ruff format --check` / `ty check src/vardax` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014thnwLaetJR3HHpAdqpcjm

---
_Generated by [Claude Code](https://claude.ai/code/session_014thnwLaetJR3HHpAdqpcjm)_